### PR TITLE
explicit encoding for pugixml

### DIFF
--- a/BioFVM/pugixml.cpp
+++ b/BioFVM/pugixml.cpp
@@ -6846,7 +6846,25 @@ namespace pugi
 		if (!(flags & format_no_declaration) && !impl::has_declaration(_root))
 		{
 			buffered_writer.write_string(PUGIXML_TEXT("<?xml version=\"1.0\""));
-			if (encoding == encoding_latin1) buffered_writer.write_string(PUGIXML_TEXT(" encoding=\"ISO-8859-1\""));
+			const char_t* decl_encoding;
+			switch (encoding)
+			{
+				case pugi::encoding_utf8: decl_encoding = PUGIXML_TEXT("UTF-8"); break;
+				case pugi::encoding_latin1: decl_encoding = PUGIXML_TEXT("ISO-8859-1"); break;
+				case pugi::encoding_utf16: decl_encoding = PUGIXML_TEXT("UTF-16"); break;
+				case pugi::encoding_utf16_le: decl_encoding = PUGIXML_TEXT("UTF-16"); break;
+				case pugi::encoding_utf16_be: decl_encoding = PUGIXML_TEXT("UTF-16"); break;
+				case pugi::encoding_utf32: decl_encoding = PUGIXML_TEXT("UTF-32"); break;
+				case pugi::encoding_utf32_le: decl_encoding = PUGIXML_TEXT("UTF-32"); break;
+				case pugi::encoding_utf32_be: decl_encoding = PUGIXML_TEXT("UTF-32"); break;
+				default: decl_encoding = nullptr; // Don't write anything
+			}
+			if (decl_encoding)
+			{
+				buffered_writer.write_string(PUGIXML_TEXT(" encoding=\""));
+				buffered_writer.write_string(decl_encoding);
+				buffered_writer.write('"');
+			}
 			buffered_writer.write('?', '>');
 			if (!(flags & format_raw)) buffered_writer.write('\n');
 		}

--- a/modules/PhysiCell_settings.cpp
+++ b/modules/PhysiCell_settings.cpp
@@ -1268,7 +1268,7 @@ void set_intracellular_files(pugi::xml_node &node_config_intracellular, const pu
 		pugi::xml_document rr_doc;
 		rr_doc.append_copy(node_rr_root);
 		std::string rr_filename = base_path_to_filename + "_" + intracellular_type + ".xml";
-		rr_doc.save_file(rr_filename.c_str());
+		rr_doc.save_file(rr_filename.c_str(), PUGIXML_TEXT("\t"), pugi::format_default, pugi::encoding_utf8);
 		pugi::xml_node node_sbml_filename = node_config_intracellular.child("sbml_filename");
 		if (!node_sbml_filename)
 		{


### PR DESCRIPTION
pugixml will only specify the encoding it it is latin1, i.e. ISO-8859-1. this might cause problems with some systems that use something called BOM to determine the encoding. so I have modified the pugixml.cpp to write out the encoding any time it is passed (among cases in a switch statement).