### PR TITLE
fix CRLF line endings breaking CSV parsers on Unix/macOS

### DIFF
--- a/BioFVM/BioFVM_microenvironment.cpp
+++ b/BioFVM/BioFVM_microenvironment.cpp
@@ -47,6 +47,7 @@
 */
 
 #include "BioFVM_microenvironment.h"
+#include "BioFVM_utilities.h"
 #include "BioFVM_solvers.h"
 #include "BioFVM_vector.h"
 #include <cmath>
@@ -1303,14 +1304,15 @@ void load_initial_conditions_from_csv(std::string filename)
 		exit(-1);
 	}
 
-	// determine if header row exists 
-	std::string line; 
+	// determine if header row exists
+	std::string line;
 	std::getline( file , line );
+	trim_cr(line);
 	char c = line.c_str()[0];
 	std::vector<int> substrate_indices;
 	bool header_provided = false;
 	if( c == 'X' || c == 'x' )
-	{ 
+	{
 		if ((line.c_str()[2] != 'Y' && line.c_str()[2] != 'y') || (line.c_str()[4] != 'Z' && line.c_str()[4] != 'z'))
 		{
 			std::cout << "ERROR: Header row starts with x but then not y,z? What is this? Exiting now." << std::endl;
@@ -1353,6 +1355,7 @@ void load_initial_conditions_from_csv(std::string filename)
 		file.close();
 		std::ifstream file(filename, std::ios::in);
 		std::getline(file, line);
+		trim_cr(line);
 	}
 
 	std::cout << "Loading substrate initial conditions from CSV file " << filename << " ... " << std::endl;
@@ -1360,6 +1363,7 @@ void load_initial_conditions_from_csv(std::string filename)
 
 	while (std::getline(file, line))
 	{
+		trim_cr(line);
 		get_row_from_substrate_initial_condition_csv(voxel_is_set, line, substrate_indices, header_provided);
 	}
 
@@ -1624,15 +1628,16 @@ void load_dirichlet_conditions_from_csv(std::string filename)
 		exit(-1);
 	}
 
-	// determine if header row exists 
-	std::string line; 
+	// determine if header row exists
+	std::string line;
 	std::getline( file , line );
+	trim_cr(line);
 	char c = line.c_str()[0];
 	std::vector<int> substrate_indices;
 	bool header_provided = false;
 	int n_cols;
 	if( c == 'X' || c == 'x' )
-	{ 
+	{
 		if ((line.c_str()[2] != 'Y' && line.c_str()[2] != 'y') || (line.c_str()[4] != 'Z' && line.c_str()[4] != 'z'))
 		{
 			std::cout << "ERROR: Header row starts with x but then not y,z? What is this? Exiting now." << std::endl;
@@ -1677,6 +1682,7 @@ void load_dirichlet_conditions_from_csv(std::string filename)
 		file.close();
 		std::ifstream file(filename, std::ios::in);
 		std::getline(file, line);
+		trim_cr(line);
 	}
 
 	std::cout << "Loading substrate dirichlet conditions from CSV file " << filename << " ... " << std::endl;
@@ -1684,6 +1690,7 @@ void load_dirichlet_conditions_from_csv(std::string filename)
 
 	while (std::getline(file, line))
 	{
+		trim_cr(line);
 		get_row_from_dirichlet_condition_csv(voxel_is_set, line, substrate_indices, header_provided, n_cols);
 	}
 

--- a/BioFVM/BioFVM_utilities.h
+++ b/BioFVM/BioFVM_utilities.h
@@ -78,9 +78,12 @@ void seed_random( void );
 double uniform_random( void );
 
 double compute_mean( std::vector<double>& values );
-double compute_variance( std::vector<double>& values, double mean ); 
-double compute_variance( std::vector<double>& values ); 
-	
+double compute_variance( std::vector<double>& values, double mean );
+double compute_variance( std::vector<double>& values );
+
+inline void trim_cr( std::string& line )
+{ if (!line.empty() && line.back() == '\r') { line.pop_back(); } }
+
 };
  
 #endif 

--- a/addons/PhysiECM/extracellular_matrix.cpp
+++ b/addons/PhysiECM/extracellular_matrix.cpp
@@ -218,9 +218,10 @@ void initialize_ecm_from_csv(std::string path_to_ic_ecm_file)
 		exit(-1);
 	}
 
-	// determine if header row exists 
-	std::string line; 
+	// determine if header row exists
+	std::string line;
 	std::getline( file , line );
+	trim_cr(line);
 	char c = line.c_str()[0];
 	if( c == 'X' || c == 'x' )
 	{ 
@@ -269,6 +270,7 @@ void initialize_ecm_from_csv(std::string path_to_ic_ecm_file)
 
 	while (std::getline(file, line))
 	{
+		trim_cr(line);
 		std::vector<double> data;
 		csv_to_vector(line.c_str(), data);
 

--- a/core/PhysiCell_rules.cpp
+++ b/core/PhysiCell_rules.cpp
@@ -1541,8 +1541,9 @@ void parse_csv_rules_v0( std::string filename )
 
 	while( fs.eof() == false )
 	{
-		std::string line; 	
-		std::getline( fs , line, '\n'); 
+		std::string line;
+		std::getline( fs , line, '\n');
+		trim_cr(line);
 		if( line.size() > 0 )
 		{ parse_csv_rule_v0(line); }
 	}
@@ -1677,8 +1678,9 @@ void parse_csv_rules_v1( std::string filename )
 
 	while( fs.eof() == false )
 	{
-		std::string line; 	
-		std::getline( fs , line, '\n'); 
+		std::string line;
+		std::getline( fs , line, '\n');
+		trim_cr(line);
 		if( line.size() > 0 )
 		{ parse_csv_rule_v1(line); }
 	}
@@ -1810,8 +1812,9 @@ void parse_csv_rules_v3( std::string filename )
 
 	while( fs.eof() == false )
 	{
-		std::string line; 	
-		std::getline( fs , line, '\n'); 
+		std::string line;
+		std::getline( fs , line, '\n');
+		trim_cr(line);
 		if( line.size() > 0 )
 		{ parse_csv_rule_v3(line); }
 	}

--- a/core/PhysiCell_rules_extended.cpp
+++ b/core/PhysiCell_rules_extended.cpp
@@ -936,8 +936,9 @@ void parse_csv_behavior_rules(std::string path_to_file, std::string protocol, do
 
 	while( fs.eof() == false )
 	{
-		std::string line; 	
-		std::getline( fs , line, '\n'); 
+		std::string line;
+		std::getline( fs , line, '\n');
+		trim_cr(line);
 		if( line.size() > 0 )
 		{ parse_csv_behavior_rule(line); }
 	}

--- a/modules/PhysiCell_geometry.cpp
+++ b/modules/PhysiCell_geometry.cpp
@@ -308,8 +308,9 @@ void load_cells_csv_v1( std::string filename )
 	std::string line;
 	while (std::getline(file, line))
 	{
+		trim_cr(line);
 		std::vector<double> data;
-		csv_to_vector( line.c_str() , data ); 
+		csv_to_vector( line.c_str() , data );
 
 		if( data.size() != 4 )
 		{
@@ -858,17 +859,21 @@ void load_cells_csv_v2( std::string filename )
 
 	// get the first line (labels)
 
-	std::string line; 
-	std::getline( file , line ); 
+	std::string line;
+	std::getline( file , line );
+	trim_cr(line);
 
-	// tokenize the labels 
+	// tokenize the labels
 
-	std::vector<std::string> labels = split_csv_labels( line ); 
+	std::vector<std::string> labels = split_csv_labels( line );
 
-	// process all remaining lines 
+	// process all remaining lines
 
 	while (std::getline(file, line))
-	{ process_csv_v2_line(line,labels); }	
+	{
+		trim_cr(line);
+		process_csv_v2_line(line,labels);
+	}
 
 	// close the file 
 
@@ -889,9 +894,10 @@ void load_cells_csv( std::string filename )
 	}
 
 	// determine version 
-	std::string line; 
+	std::string line;
 	std::getline( file , line );
-	char c = line.c_str()[0]; 
+	trim_cr(line);
+	char c = line.c_str()[0];
 
 	file.close(); 
 


### PR DESCRIPTION
std::getline does not strip \r on Unix when files have Windows-style CRLF endings (common from Excel exports). Added trim_cr() as an inline utility in BioFVM_utilities.h and called it after every file-level getline in the cell, rules, substrate IC, Dirichlet condition, ECM IC, and extended rules CSV parsers.