### PR TITLE
Enhance CSV parser to skip blank lines and validate column count

### DIFF
--- a/VERSION.txt
+++ b/VERSION.txt
@@ -1,1 +1,1 @@
-1.14.2-drbergman-2.5.1
+1.14.2-drbergman-2.5.2

--- a/modules/PhysiCell_geometry.cpp
+++ b/modules/PhysiCell_geometry.cpp
@@ -312,7 +312,9 @@ void load_cells_csv_v1( std::string filename )
 		std::vector<double> data;
 		csv_to_vector( line.c_str() , data );
 
-		if( data.size() != 4 )
+		if (data.size() == 0)
+		{ continue; } // skip blank lines
+		else if( data.size() != 4 )
 		{
 			std::cerr << "Error! Importing cells from a CSV file expects each row to be x,y,z,typeID." << std::endl;
 			exit(-1);
@@ -759,6 +761,15 @@ Cell* process_csv_v2_line( std::string line , std::vector<std::string> labels )
 	std::string s; 
 	while( std::getline( stream , s , ',' ) )
 	{ tokens.push_back(s); }
+
+	// check that we have enough tokens and protect against blank lines
+	if ( tokens.size() == 0 )
+	{ return NULL; }
+	else if (tokens.size() < 4)
+	{
+		std::cerr << "Error: CSV file expects at least 4 columns (x,y,z,cell_type) but found " << tokens.size() << std::endl;
+		exit(-1);
+	}
 
 	// get the cell position 
 	std::vector<double> position; 


### PR DESCRIPTION
For misspecified cells.csv rows, the error is a cryptic segfault. This makes the error clear and also skips over any blank lines, including a file that ends with two blank lines. Now, the following cells.csv files work for the template project (with initial condition enabled)

extra blank line at end:
```csv
x,y,z,type
0,0,0,default


```
skipped line (perhaps to separate cell types or just an innocent mistake):
```csv
x,y,z,type
0,0,0,default

10,0,0,default
```
throws a clear error message on misspecified csvs:
```csv
x,y,z,type
0,0,0,default
0,1,default
```