### PR TITLE
Remove uninitialized system() call from PhysiPKPD sample projects

### DIFF
--- a/sample_projects_physipkpd/confluence_start-deprecated/main.cpp
+++ b/sample_projects_physipkpd/confluence_start-deprecated/main.cpp
@@ -91,13 +91,6 @@ int main( int argc, char* argv[] )
 	// load and parse settings file(s)
 	load_PhysiCell_config_file();
 	
-	char copy_command [1024]; 
-	
-	// copy config file to output directry
-	system( copy_command );
-
-	sprintf( copy_command , "cp %s %s/PhysiCell_settings.xml" , argument_parser.path_to_config_file.c_str(), PhysiCell_settings.folder.c_str() ); //, PhysiCell_settings.folder.c_str() ); 
-
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);
 

--- a/sample_projects_physipkpd/moa_apoptosis/main.cpp
+++ b/sample_projects_physipkpd/moa_apoptosis/main.cpp
@@ -91,13 +91,6 @@ int main( int argc, char* argv[] )
 	// load and parse settings file(s)
 	load_PhysiCell_config_file();
 	
-	char copy_command [1024]; 
-	
-	// copy config file to output directry
-	system( copy_command );
-
-	sprintf( copy_command , "cp %s %s/PhysiCell_settings.xml" , argument_parser.path_to_config_file.c_str(), PhysiCell_settings.folder.c_str() ); //, PhysiCell_settings.folder.c_str() ); 
-
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);
 

--- a/sample_projects_physipkpd/moa_motility/main.cpp
+++ b/sample_projects_physipkpd/moa_motility/main.cpp
@@ -91,13 +91,6 @@ int main( int argc, char* argv[] )
 	// load and parse settings file(s)
 	load_PhysiCell_config_file();
 	
-	char copy_command [1024]; 
-	
-	// copy config file to output directry
-	system( copy_command );
-
-	sprintf( copy_command , "cp %s %s/PhysiCell_settings.xml" , argument_parser.path_to_config_file.c_str(), PhysiCell_settings.folder.c_str() ); //, PhysiCell_settings.folder.c_str() ); 
-
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);
 

--- a/sample_projects_physipkpd/moa_necrosis/main.cpp
+++ b/sample_projects_physipkpd/moa_necrosis/main.cpp
@@ -91,13 +91,6 @@ int main( int argc, char* argv[] )
 	// load and parse settings file(s)
 	load_PhysiCell_config_file();
 	
-	char copy_command [1024]; 
-	
-	// copy config file to output directry
-	system( copy_command );
-
-	sprintf( copy_command , "cp %s %s/PhysiCell_settings.xml" , argument_parser.path_to_config_file.c_str(), PhysiCell_settings.folder.c_str() ); //, PhysiCell_settings.folder.c_str() ); 
-
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);
 

--- a/sample_projects_physipkpd/moa_proliferation/main.cpp
+++ b/sample_projects_physipkpd/moa_proliferation/main.cpp
@@ -91,13 +91,6 @@ int main( int argc, char* argv[] )
 	// load and parse settings file(s)
 	load_PhysiCell_config_file();
 	
-	char copy_command [1024]; 
-	
-	// copy config file to output directry
-	system( copy_command );
-
-	sprintf( copy_command , "cp %s %s/PhysiCell_settings.xml" , argument_parser.path_to_config_file.c_str(), PhysiCell_settings.folder.c_str() ); //, PhysiCell_settings.folder.c_str() ); 
-
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);
 

--- a/sample_projects_physipkpd/template_pkpd/main.cpp
+++ b/sample_projects_physipkpd/template_pkpd/main.cpp
@@ -91,11 +91,6 @@ int main( int argc, char* argv[] )
 	// load and parse settings file(s)
 	load_PhysiCell_config_file();
 	
-	char copy_command [1024]; 
-	
-	// copy config file to output directry
-	system(copy_command);
-
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);
 

--- a/sample_projects_physipkpd/template_pkpd_sbml/main.cpp
+++ b/sample_projects_physipkpd/template_pkpd_sbml/main.cpp
@@ -91,13 +91,6 @@ int main( int argc, char* argv[] )
 	// load and parse settings file(s)
 	load_PhysiCell_config_file();
 	
-	char copy_command [1024]; 
-	
-	// copy config file to output directry
-	system( copy_command );
-
-	sprintf( copy_command , "cp %s %s/PhysiCell_settings.xml" , argument_parser.path_to_config_file.c_str(), PhysiCell_settings.folder.c_str() ); //, PhysiCell_settings.folder.c_str() ); 
-
 	// OpenMP setup
 	omp_set_num_threads(PhysiCell_settings.omp_num_threads);
 	


### PR DESCRIPTION
Seven `main.cpp` files under `sample_projects_physipkpd/` declare a 1024-byte stack buffer and pass it straight to `system()` without ever writing to it:

```cpp
char copy_command [1024];

// copy config file to output directry
system( copy_command );

sprintf( copy_command , "cp %s %s/PhysiCell_settings.xml" , ... );   // never executed
```

The `system()` call runs *before* the `sprintf`, so the shell receives 1024 bytes of uninitialized stack as a command, and the `cp` that was actually intended is built into the buffer and then discarded. `template_pkpd/main.cpp` doesn't even have the `sprintf` — just the bare call.

### Why this is worth fixing rather than leaving alone

Whatever those bytes happen to contain is executed by `/bin/sh`. On a Linux cluster this shows up in job stderr as

```
sh: line 1: $'\001': command not found
sh: line 1: $'\0202\246R\303\177': command not found
```

which is the shell trying to run process-startup residue as a command name. It is non-deterministic, it varies with the environment, and if those bytes ever spell something executable there is nothing to stop it running.

It is invisible on macOS, where the main thread's stack arrives zero-filled so the buffer reads as `""` and `system("")` is a silent no-op. That asymmetry is why it has survived local testing.

### Why removal rather than repair

The copy these blocks were meant to perform is already done in core: `load_PhysiCell_config_file()` calls `copy_file_to_output(argument_parser.path_to_config_file, "PhysiCell_settings.xml")` at `modules/PhysiCell_settings.cpp:137`. The blocks are pure vestige from before that moved into core.

`sample_projects/template/main.cpp` already had the same block removed, so this brings the PhysiPKPD samples back in line with it — the resulting whitespace is byte-identical to the template's.

### Scope

47 lines deleted across 7 files, no additions.

Left alone deliberately:
- `sample_projects/episode/main.cpp` and the two `sample_projects_intracellular/boolean/*/main.cpp` files — these declare, `sprintf`, then `system()` in the correct order, so they work. They are now redundant with core's copy, but that is a separate cleanup.
- `sample_projects_physipkpd/combo/main.cpp` — has no such block.

### Verification

`clang++ -fsyntax-only -std=c++11 -fopenmp` on a modified `template_pkpd/main.cpp` in the layout `make template_pkpd` produces: exit 0, no new diagnostics. `grep -rn copy_command sample_projects_physipkpd/` returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)