### PR TITLE
Give each cell definition its own fixed_duration and death-phase parameters

### DIFF
--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -1842,7 +1842,9 @@ void display_cell_definitions( std::ostream& os )
 			<< " with rate " << pCD->phenotype.death.rates[k] << " 1/min" << std::endl; 
 
 			Cycle_Model* pCM = (pCD->phenotype.death.models[k] ); 
-			Cycle_Data* pCMD = &(pCD->phenotype.death.models[k]->data ); 
+			// phases and links come from the shared model, but the parameters are
+			// per-definition now, so take those from model_data (#199) 
+			Cycle_Data* pCMD = &(pCD->phenotype.death.model_data[k] ); 
 
 			
 			os << "\t\tdeath phase transitions: " << std::endl 

--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -506,8 +506,10 @@ void Cell::start_death( int death_model_index )
 {
 	// set the death data struture to the indicated death model 
 	phenotype.death.trigger_death( death_model_index ); 
-	// change the cycle model to the current death model 
-	phenotype.cycle.sync_to_cycle_model( phenotype.death.current_model() ); 
+	// change the cycle model to the current death model, taking the parameters
+	// from this cell definition rather than from the shared model (#199) 
+	phenotype.cycle.sync_to_cycle_model( phenotype.death.current_model() , 
+		phenotype.death.current_model_data() ); 
 		
 	// turn off secretion, and reduce uptake by a factor of 10 
 	phenotype.secretion.set_all_secretion_to_zero();
@@ -2267,8 +2269,9 @@ Cell_Definition* initialize_cell_definition_from_pugixml( pugi::xml_node cd_node
 				
 				// set the transition rate 
 				pCD->phenotype.cycle.data.transition_rate(start,end) = value; 
-				// set it to fixed / non-fixed 
-				pCD->phenotype.cycle.model().phase_link(start,end).fixed_duration = fixed; 
+				// set it to fixed / non-fixed -- into this definition's own data, not
+				// the shared Cycle_Model (#199) 
+				pCD->phenotype.cycle.data.fixed_duration(start,end) = fixed; 
 				
 				node = node.next_sibling( "rate" ); 
 			}
@@ -2296,7 +2299,7 @@ Cell_Definition* initialize_cell_definition_from_pugixml( pugi::xml_node cd_node
 				// set the transition rate 
 				pCD->phenotype.cycle.data.exit_rate(start) = 1.0 / (value+1e-16); 
 				// set it to fixed / non-fixed 
-				pCD->phenotype.cycle.model().phase_links[start][0].fixed_duration = fixed; 
+				pCD->phenotype.cycle.data.exit_fixed_duration(start) = fixed; 
 				
 				node = node.next_sibling( "duration" ); 
 			}
@@ -2560,9 +2563,10 @@ Cell_Definition* initialize_cell_definition_from_pugixml( pugi::xml_node cd_node
 					double value = xml_get_my_double_value( node1 ); 
 					
 					// set the transition rate 
-					pCD->phenotype.death.models[death_index]->transition_rate(start,end) = value; 
-					// set it to fixed / non-fixed 
-					pCD->phenotype.death.models[death_index]->phase_link(start,end).fixed_duration = fixed; 
+					pCD->phenotype.death.model_data[death_index].transition_rate(start,end) = value; 
+					// set it to fixed / non-fixed -- into this definition's own copy, not
+					// the shared Cycle_Model (#199) 
+					pCD->phenotype.death.model_data[death_index].fixed_duration(start,end) = fixed; 
 					
 					node1 = node1.next_sibling( "rate" ); 
 				}
@@ -2584,10 +2588,11 @@ Cell_Definition* initialize_cell_definition_from_pugixml( pugi::xml_node cd_node
 					double value = xml_get_my_double_value( node ); 
 					
 					// set the transition rate 
-					pCD->phenotype.death.models[death_index]->data.exit_rate(start) 
+					pCD->phenotype.death.model_data[death_index].exit_rate(start) 
 						= 1.0 / (value+1e-16); 
-					// set it to fixed / non-fixed 
-					pCD->phenotype.death.models[death_index]->phase_links[start][0].fixed_duration 
+					// set it to fixed / non-fixed -- into this definition's own copy, not
+					// the shared Cycle_Model (#199) 
+					pCD->phenotype.death.model_data[death_index].exit_fixed_duration(start) 
 						= fixed; 
 					
 					node = node.next_sibling( "duration" ); 

--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -367,8 +367,10 @@ void Cell::advance_bundled_phenotype_functions( double dt_ )
 	// check for new death events 
 	if( phenotype.death.check_for_death( dt_ ) == true )
 	{
-		// if so, change the cycle model to the current death model 
-		phenotype.cycle.sync_to_cycle_model( phenotype.death.current_model() ); 
+		// if so, change the cycle model to the current death model, taking the
+		// parameters from this cell definition rather than from the shared model (#199) 
+		phenotype.cycle.sync_to_cycle_model( phenotype.death.current_model() , 
+			phenotype.death.current_model_data() ); 
 		
 		// also, turn off motility.
 		

--- a/core/PhysiCell_phenotype.cpp
+++ b/core/PhysiCell_phenotype.cpp
@@ -94,7 +94,6 @@ Phase_Link::Phase_Link()
 	start_phase_index = 0; 
 	end_phase_index = 0; 
 	
-	fixed_duration = false; 
 	
 	arrest_function = NULL; 
 	exit_function = NULL; 
@@ -126,6 +125,7 @@ void Cycle_Data::sync_to_cycle_model( void )
 	// querying the phase_links 
 
 	transition_rates.resize( n );
+	fixed_durations.resize( n );
 	
 	// also make sure the transition_rates[] are the right size 
 	
@@ -136,6 +136,7 @@ void Cycle_Data::sync_to_cycle_model( void )
 		{
 			inverse_index_maps[i][ pCycle_Model->phase_links[i][j].end_phase_index ] = j;
 			transition_rates[i].resize( pCycle_Model->phase_links[i].size() ); 
+			fixed_durations[i].resize( pCycle_Model->phase_links[i].size() , (char) 0 ); 
 		}
 	}
 
@@ -150,6 +151,16 @@ double& Cycle_Data::transition_rate( int start_phase_index , int end_phase_index
 double& Cycle_Data::exit_rate(int phase_index )
 {
 	return transition_rates[phase_index][0]; 
+}
+
+char& Cycle_Data::fixed_duration( int start_phase_index , int end_phase_index )
+{
+	return fixed_durations[ start_phase_index ][ inverse_index_maps[start_phase_index][end_phase_index] ]; 
+}
+
+char& Cycle_Data::exit_fixed_duration( int phase_index )
+{
+	return fixed_durations[phase_index][0]; 
 }
 	
 Cycle_Model::Cycle_Model()
@@ -301,7 +312,7 @@ void Cycle_Model::advance_model( Cell* pCell, Phenotype& phenotype, double dt )
 		{
 			// check to see if we should transition 
 			bool continue_transition = false; 
-			if( phase_links[i][k].fixed_duration )
+			if( phenotype.cycle.data.fixed_durations[i][k] )
 			{
 				if( phenotype.cycle.data.elapsed_time_in_phase > ((1.0/phenotype.cycle.data.transition_rates[i][k]) - 0.5 * dt) )
 				{
@@ -398,6 +409,7 @@ int Death::add_death_model( double rate , Cycle_Model* pModel )
 {
 	rates.push_back( rate );
 	models.push_back( pModel ); 
+	model_data.push_back( pModel->data );   // seed per-definition params from the model 
 	
 	parameters.resize( rates.size() ); 
 	
@@ -408,6 +420,7 @@ int Death::add_death_model( double rate, Cycle_Model* pModel, Death_Parameters& 
 {
 	rates.push_back( rate );
 	models.push_back( pModel ); 
+	model_data.push_back( pModel->data );   // seed per-definition params from the model 
 	parameters.push_back( death_parameters ); 
 	
 	return rates.size() - 1; 
@@ -496,6 +509,11 @@ Cycle_Model& Death::current_model( void )
 	return *models[current_death_model_index]; 
 }
 
+Cycle_Data& Death::current_model_data( void )
+{
+	return model_data[ current_death_model_index ]; 
+}
+
 double& Death::apoptosis_rate(void)
 {
 	static int nApoptosis = find_death_model_index( PhysiCell_constants::apoptosis_death_model ); 
@@ -538,8 +556,15 @@ int& Cycle::current_phase_index( void )
 
 void Cycle::sync_to_cycle_model( Cycle_Model& cm )
 {
+	sync_to_cycle_model( cm , cm.data ); 
+	return; 
+}	
+
+void Cycle::sync_to_cycle_model( Cycle_Model& cm , Cycle_Data& cd )
+{
 	pCycle_Model = &cm; 
-	data = cm.data; 
+	data = cd; 
+	data.pCycle_Model = &cm; // cd may have been seeded from a different instance 
 	return; 
 }	
 

--- a/core/PhysiCell_phenotype.cpp
+++ b/core/PhysiCell_phenotype.cpp
@@ -132,11 +132,11 @@ void Cycle_Data::sync_to_cycle_model( void )
 	for( int i=0 ; i < pCycle_Model->phase_links.size() ; i++ )
 	{
 		inverse_index_maps[i].clear(); 
+		transition_rates[i].resize( pCycle_Model->phase_links[i].size() ); 
+		fixed_durations[i].resize( pCycle_Model->phase_links[i].size() , (char) 0 ); 
 		for( int j=0 ; j < pCycle_Model->phase_links[i].size() ; j++ )
 		{
 			inverse_index_maps[i][ pCycle_Model->phase_links[i][j].end_phase_index ] = j;
-			transition_rates[i].resize( pCycle_Model->phase_links[i].size() ); 
-			fixed_durations[i].resize( pCycle_Model->phase_links[i].size() , (char) 0 ); 
 		}
 	}
 
@@ -560,7 +560,7 @@ void Cycle::sync_to_cycle_model( Cycle_Model& cm )
 	return; 
 }	
 
-void Cycle::sync_to_cycle_model( Cycle_Model& cm , Cycle_Data& cd )
+void Cycle::sync_to_cycle_model( Cycle_Model& cm , const Cycle_Data& cd )
 {
 	pCycle_Model = &cm; 
 	data = cd; 

--- a/core/PhysiCell_phenotype.h
+++ b/core/PhysiCell_phenotype.h
@@ -123,8 +123,6 @@ class Phase_Link
 	int start_phase_index;
 	int end_phase_index; 
 	
-	bool fixed_duration; 
-	
 	bool (*arrest_function)( Cell* pCell, Phenotype& phenotype, double dt ); 
 		// return true if arrested, false if not 
 		
@@ -152,6 +150,13 @@ class Cycle_Data
 	
 	std::vector< std::vector<double> > transition_rates; 
 	
+	// Whether each transition is a fixed duration rather than a Poisson rate.
+	// Indexed exactly like transition_rates. char rather than bool so that
+	// fixed_duration() can hand back a reference (std::vector<bool> is a proxy
+	// container and cannot). Lives here, not in Phase_Link, because Cycle_Model
+	// objects are shared by pointer between cell definitions -- see #199.
+	std::vector< std::vector<char> > fixed_durations; 
+	
 	int current_phase_index; 
 	double elapsed_time_in_phase; 
 	
@@ -169,6 +174,10 @@ class Cycle_Data
 	double& exit_rate(int phase_index ); // This returns the first transition rate out of 
 		// phase # phase_index. It is only relevant if the phase has only one phase link 
 		// (true for many cycle models). 
+
+	// as transition_rate / exit_rate, for the fixed-duration flag 
+	char& fixed_duration(int start_phase_index, int end_phase_index ); // done 
+	char& exit_fixed_duration(int phase_index ); // done 
 };
 
 class Cycle_Model
@@ -274,6 +283,10 @@ class Cycle
 	int& current_phase_index( void ); // done 
 	
 	void sync_to_cycle_model( Cycle_Model& cm ); // done 
+	// as above, but take the parameters from cd rather than from cm.data. Needed
+	// because death Cycle_Models are shared between cell definitions, so the
+	// per-definition parameters live elsewhere -- see Death::model_data (#199). 
+	void sync_to_cycle_model( Cycle_Model& cm , Cycle_Data& cd ); // done 
 
 	Asymmetric_Division asymmetric_division;
 };
@@ -302,6 +315,11 @@ class Death
  public:
 	std::vector<double> rates; 
 	std::vector<Cycle_Model*> models; 
+	// Per-definition cycle parameters for each death model. models[] are shared
+	// Cycle_Model objects, so their own .data cannot hold per-cell-definition
+	// durations or fixed-duration flags -- see #199. Seeded from the model at
+	// add_death_model(), overridden by the XML, applied at start_death().
+	std::vector<Cycle_Data> model_data; 
 	std::vector<Death_Parameters> parameters; 
 	
 	bool dead; 
@@ -319,6 +337,7 @@ class Death
 	void trigger_death( int death_model_index ); // done 
 	
 	Cycle_Model& current_model( void ); // done
+	Cycle_Data& current_model_data( void ); // done 
 	Death_Parameters& current_parameters( void ); // done '
 
 	// ease of access

--- a/core/PhysiCell_phenotype.h
+++ b/core/PhysiCell_phenotype.h
@@ -286,7 +286,7 @@ class Cycle
 	// as above, but take the parameters from cd rather than from cm.data. Needed
 	// because death Cycle_Models are shared between cell definitions, so the
 	// per-definition parameters live elsewhere -- see Death::model_data (#199). 
-	void sync_to_cycle_model( Cycle_Model& cm , Cycle_Data& cd ); // done 
+	void sync_to_cycle_model( Cycle_Model& cm , const Cycle_Data& cd ); // done 
 
 	Asymmetric_Division asymmetric_division;
 };

--- a/core/PhysiCell_standard_models.cpp
+++ b/core/PhysiCell_standard_models.cpp
@@ -239,7 +239,7 @@ void create_ki67_models( void )
 	
 	Ki67_basic.transition_rate(0,1) = 1.0/(4.59*60.0); // MCF10A cells are ~4.59 hours in Ki67- state
 	Ki67_basic.transition_rate(1,0) = 1.0/(15.5*60.0); // length of Ki67+ states in advanced model 
-	Ki67_basic.phase_link(1,0).fixed_duration = true; 
+	Ki67_basic.data.fixed_duration(1,0) = true; 
 	
 	Ki67_basic.phases[0].entry_function = NULL; // standard_Ki67_negative_phase_entry_function;
 	Ki67_basic.phases[1].entry_function = standard_Ki67_positive_phase_entry_function;
@@ -261,8 +261,8 @@ void create_ki67_models( void )
 	Ki67_advanced.add_phase_link( 1 , 2 , NULL ); // + (pre-mitotic) to + (post-mitotic) 
 	Ki67_advanced.add_phase_link( 2 , 0 , NULL ); // + to - 
 	
-	Ki67_advanced.phase_link(1,2).fixed_duration = true; 
-	Ki67_advanced.phase_link(2,0).fixed_duration = true; 
+	Ki67_advanced.data.fixed_duration(1,2) = true; 
+	Ki67_advanced.data.fixed_duration(2,0) = true; 
 
 	Ki67_advanced.transition_rate(0,1) = 1.0/(3.62*60.0); // MCF10A cells ~3.62 hours in Ki67- in this fitted model
 	Ki67_advanced.transition_rate(1,2) = 1.0/(13.0*60.0); 
@@ -376,7 +376,7 @@ void create_cycling_quiescent_model( void )
 	
 	cycling_quiescent.transition_rate(0,1) = 1.0/(4.59*60.0); // MCF10A cells are ~4.59 hours in Ki67- state
 	cycling_quiescent.transition_rate(1,0) = 1.0/(15.5*60.0); // length of Ki67+ states in advanced model 
-	cycling_quiescent.phase_link(1,0).fixed_duration = true; 
+	cycling_quiescent.data.fixed_duration(1,0) = true; 
 	
 	cycling_quiescent.phases[0].entry_function = NULL; 
 	cycling_quiescent.phases[1].entry_function = standard_cycling_entry_function;
@@ -440,7 +440,7 @@ void create_standard_apoptosis_model( void )
 	apoptosis.transition_rate( 0, 1) = 1.0 / (8.6 * 60.0); 
 
 		// Use the deterministic model, where this phase has fixed duration
-	apoptosis.phase_link(0,1).fixed_duration = true; 
+	apoptosis.data.fixed_duration(0,1) = true; 
 	
 	return; 
 }
@@ -482,7 +482,7 @@ void create_standard_necrosis_model( void )
 	necrosis.transition_rate( 1, 2 ) = 1.0 / (60.0 * 24.0 * 60.0 ); // 60 days max  
 
 	// Deterministically remove the necrotic cell if it has been 60 days
-	necrosis.phase_link(1,2).fixed_duration = true; 
+	necrosis.data.fixed_duration(1,2) = true; 
 
 	return; 
 }	


### PR DESCRIPTION
Fixes #199.

## The bug, restated

`Death::models` is a `std::vector<Cycle_Model*>` holding the addresses of the `apoptosis` and `necrosis` globals, so every cell definition shares one death model object per death type. `Cell_Definition`'s copy constructor copies the pointer rather than the model.

`fixed_duration` lived in `Phase_Link`, inside that shared object, while the XML parser wrote it per cell definition. Each definition therefore overwrote the flag for every other one, and the last definition parsed decided for all of them — which is what @rheiland traced to `pCD->phenotype.death.models[death_index]` being the same address for every `pCD`.

This is specific to death models. The live cycle was never affected: `Cell_Functions::cycle_model` is a `Cycle_Model` held **by value**, so each definition owns its own copy of `live`, `Ki67_basic` and the rest, and its `Phase_Link` flags were already per-definition. Moving the flag out of `Phase_Link` is plumbing for the live cycle rather than a fix — its only behavioural effect there is that the flag becomes per-cell rather than per-definition, which is how `transition_rates` already worked.

## What this does

Migrates the flag from the graph structure to the param structure, which is what @MathCancer proposed on the issue.

- `Cycle_Data` gains `fixed_durations`, indexed exactly like `transition_rates`, with `fixed_duration(i,j)` and `exit_fixed_duration(i)` accessors mirroring `transition_rate(i,j)` and `exit_rate(i)`.
- `Cycle_Model::advance_model` reads the per-cell copy rather than the shared graph.
- `Phase_Link::fixed_duration` is removed. The six standard models declare their defaults through the model's own `Cycle_Data`, and those defaults still reach any cell that does not override them in XML.
- All four parser sites write per-definition. No write reaches a shared `Cycle_Model`.
- Both sites that switch a dying cell onto its death model apply the per-definition parameters: `Cell::start_death()` and the `check_for_death()` branch of `Cell::advance_bundled_phenotype_functions()`. The second one matters most, since that is the path a cell takes when it dies from its `death_rate`.
- `display_cell_definitions()` reports the per-definition death parameters. It read them from the shared model, which the parser no longer writes, so without this the startup summary would print the compiled-in defaults for every definition — and that summary is exactly what a user reads to check whether this is fixed.

## Why the cycle fix alone is not enough for death models

Worth spelling out, because the one-line version of the migration looks like it should work and does not.

There is no per-definition `Cycle_Data` for a death model. `Death` holds `rates`, `models` and `parameters`, none of which carry cycle parameters, so the parser wrote durations into the shared `models[i]->data`. And `Cycle::sync_to_cycle_model()` does `data = cm.data`, called from `Cell::start_death()` — so even a correctly per-definition flag would be overwritten from the shared model at the moment of death. Relocating `fixed_duration` on its own would have moved it from one shared object to another.

This is also the mechanism behind @rheiland's observation on the issue that the `<duration>` *value* is flattened along with the flag.

So `Death` gains `model_data`, one `Cycle_Data` per death model: seeded from the model at `add_death_model()`, written by the parser, applied at `start_death()` through a new two-argument `Cycle::sync_to_cycle_model( cm, cd )`. The single-argument form delegates to it and keeps its exact previous behaviour.

## Verification

A 7-cell-type model where six definitions specify `<phase_durations fixed_duration="true">516` for apoptosis and the last specifies `<phase_transition_rates fixed_duration="false">`, probed after `create_cell_types()`:

| | before | after |
|---|---|---|
| the six asking for `fixed_duration="true"` | `fixed=0` | `fixed=1` |
| the one asking for a rate | `fixed=0` | `fixed=0` |
| `death.models[0]` address | one shared object | still one shared object |

Separately, a definition with its apoptosis `<phase_durations>` removed entirely still reports `fixed=1` and `duration=516`, confirming the standard model's default still propagates when XML does not override it.

That table is parse-time state, though, and passing it is not the same as dying correctly, so there is also a runtime check on the same sample with `stem` transforming into `differentiated` at 4e-3/min. `stem` asks for a fixed 100 min apoptosis, `differentiated` for a fixed 700 min, and `neutrophil` — parsed last, so the one that used to win for everybody — for a rate. Logging every cell at the moment it enters a death model, over 649 deaths and 61 transformations:

| cell at death | before | after |
|---|---|---|
| `stem` | fixed=0, 516 | fixed=1, 100 |
| `differentiated` | fixed=0, 516 | fixed=1, 700 |
| `differentiated`, having transformed from `stem` | fixed=0, 516 | fixed=1, 700 |
| `neutrophil` | fixed=0, 516 | fixed=0 |
| `bacteria`, no `<phase_durations>` in XML | fixed=0, 516 | fixed=1, 516 |

A transformed cell picks up the death parameters of the definition it became, which is what you would want: `convert_to_cell_definition()` does `phenotype = cd.phenotype`, so `model_data` travels with `models` and `rates`. `death.models` and `death.model_data` stayed the same length at all 649 deaths.

The startup summary now reports it too. Same sample, `stem` asking for 100 min and `differentiated` for 700, everything else on the stock 516:

| | bacteria | blood vessel | stem | differentiated | macrophage | CD8+ T cell | neutrophil |
|---|---|---|---|---|---|---|---|
| before | 516 | 516 | 516 | 516 | 516 | 516 | 516 |
| after | 516 | 516 | **100** | **700** | 516 | 516 | 516 |

## Cost

`Death::model_data` is a `std::vector<Cycle_Data>` carried per cell, and each `Cycle_Data` holds three vectors plus one `unordered_map` per phase in `inverse_index_maps`. For two death models that is on the order of a dozen extra heap allocations per `Cell`, paid at construction and on every division. Measured on the stock `interaction-sample`, single-threaded, fixed seed, 3000 min — a config where this PR changes nothing about the run, both trees ending at exactly 1674 agents, so the delta is pure overhead: `sizeof(Cell)` goes 2080 to 2152, `sizeof(Death)` 80 to 104, and wall clock 60.2 s to 61.3 s over three replicates. Call it 2%.

The cheaper alternative is to keep the per-definition death parameters on the `Cell_Definition` and look them up by the cell's type when it dies: no per-cell storage, one lookup at death. Against that, `Death::rates` and `Death::parameters` are already per-cell and already copied on every division, and rules mutate `rates` per cell at runtime, so moving only `model_data` would make `Death` half per-cell state and half a lookup keyed on `type`. It would also foreclose per-cell death timing, which is possible today even if nothing in-tree does it, and it would put a dependency from `Cell::start_death()` into the global definitions registry. I went with per-cell storage on those grounds, but 2% is not nothing and I would switch if a maintainer prefers it.

Note the phase graph itself stays shared — this does not deep-copy `Cycle_Model` per cell, so `Phenotype` copies and cell division stay cheap.

## Compatibility

This changes results for any model whose cell definitions do not all give their death models the same parameters. Two things were being flattened onto the shared model, independently of each other:

1. the transition rate for a death phase, and
2. the boolean saying whether that phase has a deterministic length.

Whichever cell definition was parsed last set both, for every definition.

Neither is tied to how the XML expresses it. `<phase_durations>` and `<phase_transition_rates>` write the same rate slot — `exit_rate(i)` is `transition_rates[i][0]`, and `transition_rate(i,j)` resolves there too for a single-link death phase — and both read `fixed_duration` from the attribute with identical logic, so a definition can perfectly well ask for a duration with a stochastic exit or a rate with a deterministic one.

Of the two, the boolean is the more disruptive to get wrong: it switches a phase between a deterministic exit and a Poisson process with the same mean, so aggregate numbers look plausible while the variance is entirely different and the phase can be exited on its first step. The rate being flattened is a plain quantitative error.

Live cycle timing is unchanged.

`Phase_Link::fixed_duration` is removed, so out-of-tree code setting `phase_link(i,j).fixed_duration` needs `data.fixed_duration(i,j)` instead. Nothing in this repository outside `core/` uses it in C++ — the other occurrences are all XML attributes.

One consequence of removing it rather than keeping it as a seed: there is now a single authoritative location for the flag. Keeping both would mean one concept with two homes and a rule about which wins and when, which is the shape of this bug in the first place.

