### PR TITLE
Generate header dependencies so header edits trigger a rebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ Studio.zip
 /worm
 /*.exe
 
+# generated header-dependency files (-MMD)
+*.d
+
 # boolean intracellular project executables
 /invasion_model
 /PhysiBoSS_Cell_Lines

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -565,6 +570,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -689,3 +695,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/Makefile-default
+++ b/sample_projects/Makefile-default
@@ -35,7 +35,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -565,6 +570,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -689,3 +695,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/asymmetric_division/Makefile
+++ b/sample_projects/asymmetric_division/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -187,6 +192,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -311,3 +317,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/biorobots/Makefile
+++ b/sample_projects/biorobots/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -187,6 +192,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -311,3 +317,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/cancer_biorobots/Makefile
+++ b/sample_projects/cancer_biorobots/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -187,6 +192,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -311,3 +317,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/cancer_immune/Makefile
+++ b/sample_projects/cancer_immune/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -183,6 +188,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -312,3 +318,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/celltypes3/Makefile
+++ b/sample_projects/celltypes3/Makefile
@@ -41,7 +41,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -184,6 +189,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -311,3 +317,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/custom_division/Makefile
+++ b/sample_projects/custom_division/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -187,6 +192,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -311,3 +317,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/dirichlet_from_file/Makefile
+++ b/sample_projects/dirichlet_from_file/Makefile
@@ -49,7 +49,12 @@ else
 endif
 
 CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
-COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS) $(DEPFLAGS)
 LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
@@ -196,6 +201,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -320,3 +326,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/episode/Makefile
+++ b/sample_projects/episode/Makefile
@@ -51,7 +51,12 @@ else
 endif
 
 CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
-COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS) $(DEPFLAGS)
 LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
@@ -198,6 +203,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -322,3 +328,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/extended_asym_div/Makefile
+++ b/sample_projects/extended_asym_div/Makefile
@@ -49,7 +49,12 @@ else
 endif
 
 CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
-COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS) $(DEPFLAGS)
 LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
@@ -196,6 +201,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -324,3 +330,7 @@ list-user-projects:
 run:
 	rm output/*
 	./$(PROGRAM_NAME)
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/heterogeneity/Makefile
+++ b/sample_projects/heterogeneity/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -187,6 +192,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -311,3 +317,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/immune_function/Makefile
+++ b/sample_projects/immune_function/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -187,6 +192,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -311,3 +317,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/interactions/Makefile
+++ b/sample_projects/interactions/Makefile
@@ -49,7 +49,12 @@ else
 endif
 
 CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
-COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS) $(DEPFLAGS)
 LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
@@ -196,6 +201,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -320,3 +326,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/mechano/Makefile
+++ b/sample_projects/mechano/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -187,6 +192,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -311,3 +317,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/physimess/Makefile
+++ b/sample_projects/physimess/Makefile
@@ -49,7 +49,12 @@ else
 endif
 
 CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
-COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS) $(DEPFLAGS)
 LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
@@ -212,6 +217,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -336,3 +342,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/pred_prey_farmer/Makefile
+++ b/sample_projects/pred_prey_farmer/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -187,6 +192,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -312,3 +318,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/rules_sample/Makefile
+++ b/sample_projects/rules_sample/Makefile
@@ -49,7 +49,12 @@ else
 endif
 
 CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
-COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS) $(DEPFLAGS)
 LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
@@ -196,6 +201,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -320,3 +326,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/template-ecm/Makefile
+++ b/sample_projects/template-ecm/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -196,6 +201,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -320,3 +326,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/template/Makefile
+++ b/sample_projects/template/Makefile
@@ -49,7 +49,12 @@ else
 endif
 
 CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
-COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS) $(DEPFLAGS)
 LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
@@ -196,6 +201,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -320,3 +326,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/template_xml_rules/Makefile
+++ b/sample_projects/template_xml_rules/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -187,6 +192,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -311,3 +317,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/template_xml_rules_extended/Makefile
+++ b/sample_projects/template_xml_rules_extended/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -187,6 +192,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -311,3 +317,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/virus_macrophage/Makefile
+++ b/sample_projects/virus_macrophage/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -187,6 +192,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -311,3 +317,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects/worm/Makefile
+++ b/sample_projects/worm/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -187,6 +192,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -311,3 +317,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects_intracellular/boolean/cancer_invasion/Makefile
+++ b/sample_projects_intracellular/boolean/cancer_invasion/Makefile
@@ -75,7 +75,12 @@ else
 endif
 
 CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
-COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS) $(DEPFLAGS)
 LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
@@ -245,6 +250,7 @@ MaBoSS-clean:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -357,3 +363,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects_intracellular/boolean/physiboss_cell_lines/Makefile
+++ b/sample_projects_intracellular/boolean/physiboss_cell_lines/Makefile
@@ -73,7 +73,12 @@ else
 endif
 
 CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
-COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS) $(DEPFLAGS)
 LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
@@ -242,6 +247,7 @@ MaBoSS-clean:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -353,3 +359,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects_intracellular/boolean/template_BM/Makefile
+++ b/sample_projects_intracellular/boolean/template_BM/Makefile
@@ -73,7 +73,12 @@ else
 endif
 
 CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
-COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS) $(DEPFLAGS)
 LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
@@ -242,6 +247,7 @@ MaBoSS-clean:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -366,3 +372,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects_intracellular/boolean/tutorial/Makefile
+++ b/sample_projects_intracellular/boolean/tutorial/Makefile
@@ -75,7 +75,12 @@ else
 endif
 
 CFLAGS_LINK := $(shell echo $(CFLAGS) | sed -e "s/-fopenmp//g")
-COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS)  $(EXTRA_FLAGS) $(DEPFLAGS)
 LINK_COMMAND := $(CC) $(CFLAGS_LINK) $(EXTRA_FLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
@@ -246,6 +251,7 @@ MaBoSS-clean:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -358,3 +364,7 @@ unpack:
 list-user-projects:
 	@echo "user projects::"
 	@cd ./user_projects && ls -dt1 * | grep . | sed 's!empty.txt!!'
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects_intracellular/combined/template-combined/Makefile
+++ b/sample_projects_intracellular/combined/template-combined/Makefile
@@ -64,7 +64,12 @@ else
 #	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) $(LIBRR_CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(LIBRR_CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -216,6 +221,7 @@ librr_intracellular.o: ./addons/libRoadrunner/src/librr_intracellular.cpp ./addo
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -273,3 +279,7 @@ unzip:
 untar: 
 	cp ./archives/latest.tar .
 	tar -xzf latest.tar
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects_intracellular/fba/cancer_metabolism/Makefile
+++ b/sample_projects_intracellular/fba/cancer_metabolism/Makefile
@@ -45,7 +45,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPS_CFLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPS_CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o
@@ -216,6 +221,7 @@ reset:
 
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 
 data-cleanup:
@@ -246,3 +252,7 @@ unzip:
 untar:
 	cp ./archives/latest.tar .
 	tar -xzf latest.tar
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects_intracellular/fba/ecoli_acetic_switch/Makefile
+++ b/sample_projects_intracellular/fba/ecoli_acetic_switch/Makefile
@@ -97,7 +97,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) $(LIBFBA_CFLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(LIBFBA_CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o
@@ -263,6 +268,7 @@ reset:
 
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 
 data-cleanup:
@@ -296,3 +302,7 @@ unzip:
 untar:
 	cp ./archives/latest.tar .
 	tar -xzf latest.tar
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects_intracellular/ode/ode_energy/Makefile
+++ b/sample_projects_intracellular/ode/ode_energy/Makefile
@@ -64,7 +64,12 @@ else
 #	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) $(LIBRR_CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(LIBRR_CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -216,6 +221,7 @@ librr_intracellular.o: ./addons/libRoadrunner/src/librr_intracellular.cpp ./addo
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -282,3 +288,7 @@ gif:
 
 movie:
 	ffmpeg -r $(FRAMERATE) -f image2 -i $(OUTPUT)/snapshot%08d.jpg -vf "pad=ceil(iw/2)*2:ceil(ih/2)*2" -vcodec libx264 -pix_fmt yuv420p -strict -2 -tune animation -crf 15 -acodec none $(OUTPUT)/out.mp4
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects_physipkpd/combo/Makefile
+++ b/sample_projects_physipkpd/combo/Makefile
@@ -42,7 +42,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o
@@ -198,6 +203,7 @@ reset:
 
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 
 data-cleanup:
@@ -262,3 +268,7 @@ redo:
 
 rc: # reconfig
 	cp ./sample_projects_physipkpd/combo/config/pkpd_model.xml ./config/
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects_physipkpd/confluence_start-deprecated/Makefile
+++ b/sample_projects_physipkpd/confluence_start-deprecated/Makefile
@@ -42,7 +42,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o
@@ -198,6 +203,7 @@ reset:
 
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 
 data-cleanup:
@@ -262,3 +268,7 @@ redo:
 
 rc: # reconfig
 	cp ./sample_projects_physipkpd/confluence_start/config/pkpd_model.xml ./config/
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects_physipkpd/moa_apoptosis/Makefile
+++ b/sample_projects_physipkpd/moa_apoptosis/Makefile
@@ -42,7 +42,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o
@@ -199,6 +204,7 @@ reset:
 
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 
 data-cleanup:
@@ -261,3 +267,7 @@ redo:
 
 rc: # reconfig
 	cp ./sample_projects_physipkpd/moa_apoptosis/config/pkpd_model.xml ./config/
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects_physipkpd/moa_motility/Makefile
+++ b/sample_projects_physipkpd/moa_motility/Makefile
@@ -42,7 +42,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o
@@ -199,6 +204,7 @@ reset:
 
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 
 data-cleanup:
@@ -263,3 +269,7 @@ redo:
 
 rc: # reconfig
 	cp ./sample_projects_physipkpd/moa_motility/config/pkpd_model.xml ./config/
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects_physipkpd/moa_necrosis/Makefile
+++ b/sample_projects_physipkpd/moa_necrosis/Makefile
@@ -42,7 +42,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o
@@ -199,6 +204,7 @@ reset:
 
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 
 data-cleanup:
@@ -263,3 +269,7 @@ redo:
 
 rc: # reconfig
 	cp ./sample_projects_physipkpd/moa_necrosis/config/pkpd_model.xml ./config/
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects_physipkpd/moa_proliferation/Makefile
+++ b/sample_projects_physipkpd/moa_proliferation/Makefile
@@ -42,7 +42,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o
@@ -199,6 +204,7 @@ reset:
 
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 
 data-cleanup:
@@ -263,3 +269,7 @@ redo:
 
 rc: # reconfig
 	cp ./sample_projects_physipkpd/moa_proliferation/config/pkpd_model.xml ./config/
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects_physipkpd/template_pkpd/Makefile
+++ b/sample_projects_physipkpd/template_pkpd/Makefile
@@ -42,7 +42,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o
@@ -199,6 +204,7 @@ reset:
 
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 
 data-cleanup:
@@ -263,3 +269,7 @@ redo:
 
 rc: # reconfig
 	cp ./sample_projects_physipkpd/template_pkpd/config/* ./config/
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/sample_projects_physipkpd/template_pkpd_sbml/Makefile
+++ b/sample_projects_physipkpd/template_pkpd_sbml/Makefile
@@ -95,7 +95,12 @@ else
 #	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) $(LIBRR_CFLAGS)
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(LIBRR_CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o
@@ -267,6 +272,7 @@ reset:
 
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 
 data-cleanup:
@@ -331,3 +337,7 @@ redo:
 
 rc: # reconfig
 	cp ./sample_projects_physipkpd/template_pkpd_sbml/config/* ./config/
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/tests/timing/Makefile
+++ b/tests/timing/Makefile
@@ -16,7 +16,12 @@ ARCH := native # best auto-tuning
 CFLAGS := -march=$(ARCH) -O3 -fomit-frame-pointer -mfpmath=both -fopenmp -m64 -std=c++11
 #CFLAGS := -g -fopenmp -std=c++11
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 DIR := ../..
 BioFVM_OBJECTS := $(DIR)/BioFVM_vector.o $(DIR)/BioFVM_mesh.o $(DIR)/BioFVM_microenvironment.o $(DIR)/BioFVM_solvers.o $(DIR)/BioFVM_matlab.o \
@@ -42,4 +47,9 @@ all: main.cpp $(ALL_OBJECTS)
 
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -15,7 +15,12 @@ ARCH := native # best auto-tuning
 # CFLAGS := -march=$(ARCH) -Ofast -s -fomit-frame-pointer -mfpmath=both -fopenmp -m64 -std=c++11
 CFLAGS := -march=$(ARCH) -O3 -fomit-frame-pointer -mfpmath=both -fopenmp -m64 -std=c++11
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 DIR := ../..
 BioFVM_OBJECTS := $(DIR)/BioFVM_vector.o $(DIR)/BioFVM_mesh.o $(DIR)/BioFVM_microenvironment.o $(DIR)/BioFVM_solvers.o $(DIR)/BioFVM_matlab.o \
@@ -44,4 +49,9 @@ all: main.cpp $(ALL_OBJECTS)
 
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/unit_tests/cell_definition/Makefile
+++ b/unit_tests/cell_definition/Makefile
@@ -11,7 +11,12 @@ ARCH := native # best auto-tuning
 # CFLAGS := -march=$(ARCH) -Ofast -s -fomit-frame-pointer -mfpmath=both -fopenmp -m64 -std=c++11
 CFLAGS := -march=$(ARCH) -O3 -fomit-frame-pointer -mfpmath=both -fopenmp -m64 -std=c++11 -U LIBROADRUNNER 
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 ODIR := ../..
 
@@ -40,3 +45,7 @@ test_cell_def1:
 	$(COMPILE_COMMAND) -o test_cell_def1 $(ALL_OBJECTS) test_cell_def1.cpp 
 test_cell_def2: 
 	$(COMPILE_COMMAND) -o test_cell_def2 $(ALL_OBJECTS) test_cell_def2.cpp 
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/unit_tests/custom_DCs_2substrates/Makefile
+++ b/unit_tests/custom_DCs_2substrates/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -187,6 +192,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -309,3 +315,7 @@ sci_package:
 	@echo "Project saved in $(PROJ)_packaged_$$(date +%b_%d_%Y_%H%M).zip."
 	@echo "It is fully self-contained and can be distributed as a separate GitHub repository."
 	@echo " "
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/unit_tests/custom_voxel_values/Makefile
+++ b/unit_tests/custom_voxel_values/Makefile
@@ -44,7 +44,12 @@ else
 	endif
 endif
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -184,6 +189,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -306,3 +312,7 @@ sci_package:
 	@echo "Project saved in $(PROJ)_packaged_$$(date +%b_%d_%Y_%H%M).zip."
 	@echo "It is fully self-contained and can be distributed as a separate GitHub repository."
 	@echo " "
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)

--- a/unit_tests/substrate_internalization/Makefile-unit-test-conservation
+++ b/unit_tests/substrate_internalization/Makefile-unit-test-conservation
@@ -32,7 +32,12 @@ ARCH := native # best auto-tuning
 # CFLAGS := -march=$(ARCH) -Ofast -s -fomit-frame-pointer -mfpmath=both -fopenmp -m64 -std=c++11
 CFLAGS := -march=$(ARCH) -O3 -fomit-frame-pointer -mfpmath=both -fopenmp -m64 -std=c++11
 
-COMPILE_COMMAND := $(CC) $(CFLAGS) 
+# -MMD emits a .d file beside each .o listing the headers it included; -MP adds
+# a dummy target for each so that deleting or renaming a header does not break
+# the build. The .d files are read back in at the bottom of this file.
+DEPFLAGS := -MMD -MP
+
+COMPILE_COMMAND := $(CC) $(CFLAGS) $(DEPFLAGS)
 
 BioFVM_OBJECTS := BioFVM_vector.o BioFVM_mesh.o BioFVM_microenvironment.o BioFVM_solvers.o BioFVM_matlab.o \
 BioFVM_utilities.o BioFVM_basic_agent.o BioFVM_MultiCellDS.o BioFVM_agent_container.o 
@@ -151,6 +156,7 @@ reset:
 	
 clean:
 	rm -f *.o
+	rm -f *.d
 	rm -f $(PROGRAM_NAME)*
 	
 data-cleanup:
@@ -182,3 +188,7 @@ unzip:
 untar: 
 	cp ./archives/latest.tar .
 	tar -xzf latest.tar
+
+# Keep this at the end of the file: each .d declares rules for its own .o, so
+# including them any earlier would replace `all` as the default goal.
+-include $(ALL_OBJECTS:.o=.d)


### PR DESCRIPTION
Mirror of MathCancer/PhysiCell#426 for `my-physicell`. Same change, applied to this branch's 44 Makefiles rather than upstream's 30.

## The problem

Every object rule names only its `.cpp`:

```make
PhysiCell_cell.o: ./core/PhysiCell_cell.cpp
	$(COMPILE_COMMAND) -c ./core/PhysiCell_cell.cpp
```

Make rebuilds a target only when a listed prerequisite is newer, so headers are invisible to it. No object rule anywhere names a header and there is no dependency generation. Editing `core/PhysiCell_cell.h` and running `make` relinks the stale objects and reports success.

That is merely confusing when the change is behavioural. It is dangerous when the header changes a type's layout: the rebuilt objects and the stale ones disagree about member offsets and `sizeof`, the link succeeds because mangled names encode types rather than layouts, and the binary reads fields at the wrong addresses. The crash looks like a bug in whatever you were working on.

Concretely, on this branch: the `attacked_by` member added in #59 moves `sizeof(Cell)` from 2080 to 2152. An incremental build across that change produced convincing but entirely fictional use-after-free crashes, in a patch whose whole subject is use-after-free.

## The change

`-MMD` writes a `.d` file beside each `.o` listing the headers that object actually included. `-MP` adds a dummy target for each so deleting or renaming a header does not break the build. The `.d` files are read back in as prerequisites, so nothing is hand-maintained.

Three lines per Makefile:

- `DEPFLAGS := -MMD -MP`, appended to `COMPILE_COMMAND` — not to `LINK_COMMAND`, which does not compile.
- `rm -f *.d` in `clean`. `unit_tests/cell_definition/Makefile` has no `clean` target, so it gets the flags and the include and nothing else.
- `-include $(ALL_OBJECTS:.o=.d)` at the very end of the file.

`*.d` is gitignored.

The placement of that last line is load-bearing, and there is a comment in each file saying so: each `.d` declares rules for its own `.o`, so including them earlier makes the first of those the default goal, and a bare `make` would build `BioFVM_vector.o` and stop.

## Verification

Built four projects covering the shapes that differ here, including two that do not exist upstream, then touched `core/PhysiCell_cell.h` and asked make what it would do:

| project | objects | `.d` written | rebuilt after touching the header |
|---|---|---|---|
| `template` | 28 | 29 | 13 |
| `interaction-sample` | 28 | 29 | 13 |
| `template-xml-rules-extended` | 28 | 29 | 13 |

Only the objects that actually include the header rebuild, which is the point. With the current Makefiles the same touch rebuilds **zero** and goes straight to relinking.

Also confirmed: the default goal is still `all`; `make clean` removes both `.o` and `.d`; `sample_projects_intracellular/boolean/physiboss_cell_lines/Makefile` keeps its CRLF line endings; and the two Makefiles that lacked a final newline gain one, which is unavoidable when appending to them.

## One thing this surfaced but does not fix

`pkpd-apoptosis-sample` does not link on this branch, with or without this change — I checked the untouched baseline and it fails identically. `addons/PhysiPKPD/src/PhysiPKPD_PD.cpp` calls `find_ruleset( Cell_Definition* )`, which is defined in `core/PhysiCell_rules.cpp`, but every sample Makefile here links `PhysiCell_rules_extended.o` and not `PhysiCell_rules.o`. Separate issue, flagged rather than folded in.
