### PR TITLE
Read pAttackTarget once in the effector-attack block

### DIFF
--- a/core/PhysiCell_standard_models.cpp
+++ b/core/PhysiCell_standard_models.cpp
@@ -1262,11 +1262,14 @@ void standard_cell_cell_interactions( Cell* pCell, Phenotype& phenotype, double 
 
 	// move effector attack here. 
 
-		if( pCell->phenotype.cell_interactions.pAttackTarget != NULL ) 
+		// read the target once. attack_cell() dereferences without a null check, so
+		// testing this field and then reloading it would let any concurrent clear
+		// hand it a NULL. One load is free and does not depend on which teardown
+		// paths currently run inside this loop. 
+		Cell* pAttackTarget = pCell->phenotype.cell_interactions.pAttackTarget; 
+		if( pAttackTarget != NULL ) 
 		{
-			Cell* pTarget = pCell->phenotype.cell_interactions.pAttackTarget; 
-
-			pCell->attack_cell(pTarget,dt); 
+			pCell->attack_cell(pAttackTarget,dt); 
 			attacked = true; // attacked at least one cell in this time step 
 
 			// attack_cell
@@ -1276,18 +1279,18 @@ void standard_cell_cell_interactions( Cell* pCell, Phenotype& phenotype, double 
 			probability = dt / (1e-15 + pCell->phenotype.cell_interactions.attack_duration); 
 
 
-			if( UniformRandom() < probability || pTarget->phenotype.death.dead ) 
+			if( UniformRandom() < probability || pAttackTarget->phenotype.death.dead ) 
 			{
 				/*
 				std::cout << "*********   *********  ********  attack done **** " << PhysiCell_globals.current_time << " " 
 				<< probability << " "
-				<< "attack time: " << pTarget->state.total_attack_time << " " 		
-				<< "damage: " << pTarget->phenotype.cell_integrity.damage <<  " " 		
-				<< "dead? " << (int) pTarget->phenotype.death.dead << " " 
+				<< "attack time: " << pAttackTarget->state.total_attack_time << " " 		
+				<< "damage: " << pAttackTarget->phenotype.cell_integrity.damage <<  " " 		
+				<< "dead? " << (int) pAttackTarget->phenotype.death.dead << " " 
 				<< "damage delivered: " << pCell->phenotype.cell_interactions.total_damage_delivered << std::endl; 
 				*/
 
-				end_attack( pCell , pTarget );
+				end_attack( pCell , pAttackTarget );
 			} 
 		} 
 


### PR DESCRIPTION
Follow-up to #59. Mirror of the same fix on MathCancer/PhysiCell#422 (commit 6c79881), where Copilot flagged it on re-review.

#59 introduced the first cross-thread write to `phenotype.cell_interactions.pAttackTarget`. Before it, every write was to the field of the cell owned by the current loop iteration; the only cross-thread access anywhere was a read in `dynamic_spring_attachments`. `remove_all_attackers()` now writes another cell's pointer, and it runs from `standard_cell_cell_interactions` inside the mechanics parallel-for.

That turns a two-load sequence in the effector-attack block into a crash:

```cpp
if( pCell->phenotype.cell_interactions.pAttackTarget != NULL )   // load 1
{
    Cell* pTarget = pCell->phenotype.cell_interactions.pAttackTarget;  // load 2
    pCell->attack_cell(pTarget,dt);
```

If another thread clears the field between the two loads — which happens when this attacker's target is eaten, fused or lysed — `pTarget` is NULL and `attack_cell()` dereferences it straight away, since it only guards `pCell_to_attack == this`. One snapshot, used throughout, closes that: the block either sees a target it can act on, or sees NULL and does nothing.

This narrows the race rather than removing it. The field is still a plain `Cell*` read on one thread while another writes NULL to it. Removing it properly needs either the read under the same critical as the write, which puts a global lock in the mechanics hot path, or `std::atomic<Cell*>`, which is free at runtime but changes the type of a public field and would require `.load()` in any out-of-tree module that touches it. That call is worth making deliberately rather than folding in here.

Checked while looking at this: an attacker cannot end up in a target's `attacked_by` with a NULL `pAttackTarget`. Reaching `begin_attack` requires reading the field as NULL at the gate in `standard_cell_cell_interactions`, and that cannot be observed before the clearing store, so the one desync direction teardown could not repair is unreachable.

`interaction-sample` builds and runs to completion.
