### PR TITLE
Defer teardown out of the mechanics parallel-for

### DIFF
--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -1507,12 +1507,13 @@ void Cell::ingest_cell( Cell* pCell_to_eat )
 		
 	}
 
-	// things that have their own thread safety 
+	// Teardown is deferred rather than done here. flag_for_removal() queues this
+	// cell, and the serial cells_ready_to_die -> die() -> delete_cell() pass does
+	// the same four steps off-thread. Doing them here means mutating other cells'
+	// lists from inside the mechanics parallel-for, where remove_all_* walks a
+	// vector unlocked while attach/detach_cell_as_spring edits it under the
+	// critical -- a real race, not a theoretical one. 
 	pCell_to_eat->flag_for_removal();
-	pCell_to_eat->remove_all_attached_cells();
-	pCell_to_eat->remove_all_attackers();
-	pCell_to_eat->remove_self_from_attacked();
-	pCell_to_eat->remove_all_spring_attachments();
 	
 	return; 
 }
@@ -1678,11 +1679,13 @@ void Cell::fuse_cell( Cell* pCell_to_fuse )
 	}
 
 	// things that have their own thread safety 
+	// Teardown is deferred rather than done here. flag_for_removal() queues this
+	// cell, and the serial cells_ready_to_die -> die() -> delete_cell() pass does
+	// the same four steps off-thread. Doing them here means mutating other cells'
+	// lists from inside the mechanics parallel-for, where remove_all_* walks a
+	// vector unlocked while attach/detach_cell_as_spring edits it under the
+	// critical -- a real race, not a theoretical one. 
 	pCell_to_fuse->flag_for_removal();
-	pCell_to_fuse->remove_all_attached_cells();
-	pCell_to_fuse->remove_all_attackers();
-	pCell_to_fuse->remove_self_from_attacked();
-	pCell_to_fuse->remove_all_spring_attachments();
 
 	return; 
 }
@@ -1712,10 +1715,12 @@ void Cell::lyse_cell( void )
 
 	// remove all adhesions 
 	
-	remove_all_attached_cells(); 
-	remove_all_attackers();
-	remove_self_from_attacked();
-	remove_all_spring_attachments();
+	// Teardown is deferred rather than done here. flag_for_removal() queues this
+	// cell, and the serial cells_ready_to_die -> die() -> delete_cell() pass does
+	// the same four steps off-thread. Doing them here means mutating other cells'
+	// lists from inside the mechanics parallel-for, where remove_all_* walks a
+	// vector unlocked while attach/detach_cell_as_spring edits it under the
+	// critical -- a real race, not a theoretical one. 
 	
 	// set volume to zero 
 	set_total_volume( 0.0 ); 


### PR DESCRIPTION
Mirror of the same commit on MathCancer/PhysiCell#422. Opening here so it can be looked at against a branch that already has the attack link merged (#59).

## What

`ingest_cell`, `fuse_cell` and `lyse_cell` each flag their victim for removal and then immediately tear down its adhesions, springs and attack links. All three run from `standard_cell_cell_interactions`, inside the mechanics parallel-for, so that teardown mutates other cells' state from a thread that does not own them.

This drops those in-loop calls and keeps `flag_for_removal()`. The work was already redundant — `flag_for_removal()` queues the cell, and the serial `cells_ready_to_die` → `die()` → `delete_cell()` pass performs the same four steps.

## Why it is a real race

`remove_all_spring_attachments()` walks `state.spring_attachments` by index with **no lock**:

```cpp
for( int i = 0; i < state.spring_attachments.size() ; i++ )
{ state.spring_attachments[i]->detach_cell_as_spring( this ); }
```

while `attach_cell_as_spring` and `detach_cell_as_spring` edit that same vector under the unnamed critical. `detach` is swap-and-pop, so if the writer removes an entry below the walker's cursor, the tail element is moved into a slot the walker has already passed and never gets detached — leaving a neighbour holding a pointer to a cell that is about to be freed. A `push_back` that reallocates is worse. `remove_all_attached_cells()` has the identical shape against `attach_cell`/`detach_cell`.

The `maximum_number_of_attachments` check lives only in `dynamic_attachments`/`dynamic_spring_attachments`, which run in a different loop, so they cannot collide — but the attack path reaches `attach_cells_as_spring` from inside this loop, and so can the teardown of a cell being eaten at the same moment.

## Evidence

Instrumented the unlocked walk to publish which cell each thread is tearing down, and checked for a collision inside the locked mutators. On stock `interaction-sample` at 8 threads:

| | in-loop teardown | deferred |
|---|---|---|
| seeds with a collision | **3 of 6** | **0 of 6** |
| teardowns walked | ~1500 | ~900 |

The halving is the duplicate pass going away. The same harness finds this on pristine upstream `development` too — 4 of 6 seeds — so it predates the attack link rather than being introduced by it.

Single-threaded with a fixed seed, output is bit-identical: no `cells.mat` and no microenvironment file differs across three seeds. Only the wall-clock string embedded in the SVGs changes.

## Relationship to other work

MathCancer/PhysiCell#427 fixes an overlapping race in the same loop by wrapping the whole `standard_cell_cell_interactions` call in `#pragma omp ordered`, but gates it behind `use_counter_based_rng`, which is off by default — its description says the race remains on the default path. This removes the cross-cell mutation instead of serialising around it, so it applies unconditionally and costs nothing.

Not fixed here, and worth its own issue: attack-induced springs never consult `maximum_number_of_attachments`, so a cell can exceed the cap deterministically, single-threaded. That is a missing check rather than a race, and no amount of ordering addresses it.
