### PR TITLE
Make the asymmetric division probability tolerance configurable

### DIFF
--- a/core/PhysiCell_standard_models.cpp
+++ b/core/PhysiCell_standard_models.cpp
@@ -1325,8 +1325,9 @@ void asymmetric_division_function( Cell* pCell_parent, Cell* pCell_daughter )
 	int parent_type = pCell_parent->type;
 	Asymmetric_Division& parent_asym_div = pCell_parent->phenotype.cycle.asymmetric_division;
 	// probabilities meant to sum to exactly 1 land a hair over it in double precision:
-	// 0.11 + 0.33 + 0.56 is 1.000000000000000222
-	static const double tolerance = 1e-12;
+	// 0.11 + 0.33 + 0.56 is 1.000000000000000222. Configurable because how much slack a model
+	// needs depends on how many probabilities it sums and how they are computed.
+	const double tolerance = PhysiCell_settings.asymmetric_division_probability_tolerance;
 	double total = parent_asym_div.probabilities_total();
 	if (total > 1.0 + tolerance)
 	{

--- a/modules/PhysiCell_settings.cpp
+++ b/modules/PhysiCell_settings.cpp
@@ -334,6 +334,19 @@ void PhysiCell_Settings::read_from_pugixml( void )
 			PhysiCell_settings.disable_automated_spring_adhesions = true;
 		}
 
+		if( node_options.child( "asymmetric_division_probability_tolerance" ) )
+		{
+			double tol = xml_get_double_value( node_options, "asymmetric_division_probability_tolerance" );
+			if( tol < 0.0 )
+			{
+				std::cerr << "Error: <asymmetric_division_probability_tolerance> is " << tol
+					<< ", but it must not be negative." << std::endl;
+				exit(-1);
+			}
+			PhysiCell_settings.asymmetric_division_probability_tolerance = tol;
+			std::cout << "Using asymmetric division probability tolerance " << tol << std::endl;
+		}
+
 		// NOTE: the random seed is read in setup_random_seed_from_config(), which runs
 		// after the output folder is finalized so random_seed.txt is written there.
 

--- a/modules/PhysiCell_settings.h
+++ b/modules/PhysiCell_settings.h
@@ -117,6 +117,12 @@ class PhysiCell_Settings
 	bool enable_legacy_saves = false;
 
 	bool disable_automated_spring_adhesions = false;
+
+	// slack allowed when checking that asymmetric division probabilities sum to at most 1.
+	// Probabilities meant to sum to exactly 1 land a hair over it in double precision:
+	// 0.11 + 0.33 + 0.56 is 1.000000000000000222. Override with <asymmetric_division_probability_tolerance>
+	// in the <options> block.
+	double asymmetric_division_probability_tolerance = 1e-12;
 	
 	double SVG_save_interval = 60;
 	bool enable_SVG_saves = true;


### PR DESCRIPTION
`asymmetric_division_function` allows a small excess when checking that the asymmetric division probabilities sum to at most 1 — probabilities meant to sum to exactly 1 land a hair over it in double precision, `0.11 + 0.33 + 0.56` being `1.000000000000000222`. Since 3.0.0 that tolerance has been `1e-12`, hard-coded.

That is the right default but not right for every model. How much slack is needed depends on how many probabilities are summed and how they are produced. A model whose probabilities come from **rules** rather than XML literals can exceed 1 by far more than `1e-12` — excesses around `8e-3` have been observed in practice — and such a model currently exits with no way to declare that acceptable.

## Change

A new `<asymmetric_division_probability_tolerance>` in the `<options>` block:

```xml
<options>
    <asymmetric_division_probability_tolerance>1e-6</asymmetric_division_probability_tolerance>
</options>
```

- **Absent** — the default `1e-12` applies and nothing is printed. Existing configs are unaffected.
- **Present** — the value is used, and echoed once at startup so it appears in the log.
- **Negative** — rejected at parse time, rather than silently inverting the comparison and disabling both guards.

3 files, +22/−2. The name says which quantity is toleranced: slack on the probability **sum**, not on division timing or on the division itself.

## Verified

Built the `asymmetric-division` sample project and ran all three cases:

| config | exit | output |
|---|---|---|
| tag absent | 0 | *(nothing — default in effect)* |
| `1e-6` | 0 | `Using asymmetric division probability tolerance 1e-06` |
| `-1` | 255 | `Error: <asymmetric_division_probability_tolerance> is -1, but it must not be negative.` |

## Note

This only widens the band in which an over-specified distribution is *accepted and absorbed*. It does not reintroduce rescaling — a distribution that genuinely exceeds 1 beyond the tolerance still reports and exits, unchanged from 3.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
