### PR TITLE
Take spring attachments under the lock before iterating them

### DIFF
--- a/core/PhysiCell_standard_models.cpp
+++ b/core/PhysiCell_standard_models.cpp
@@ -1406,10 +1406,25 @@ void dynamic_spring_attachments( Cell* pCell , Phenotype& phenotype, double dt )
 {
     // check for detachments 
     double detachment_probability = phenotype.mechanics.detachment_rate * dt; 
+
+	// This runs inside the mechanics parallel-for, and this loop is not the only
+	// thing touching pCell's spring list: another thread running this same function
+	// for a neighbor calls attach_cells_as_spring(), which reaches into THIS cell's
+	// spring_attachments and push_back()s. Those writers serialize on the unnamed
+	// critical in Cell::attach_cell_as_spring() / detach_cell_as_spring(); reading
+	// here without it means a concurrent push_back that reallocates leaves the loop
+	// indexing a freed buffer and dereferencing garbage. Copy under the same lock
+	// and walk the copy.
+	// The lock is not held across the loop body: detach_cells_as_spring() takes the
+	// same unnamed critical, and OpenMP criticals are not reentrant.
+	std::vector<Cell*> spring_attachments_snapshot;
+	#pragma omp critical
+	{ spring_attachments_snapshot = pCell->state.spring_attachments; }
+
 	// detach_cells_as_spring swaps the detached cell with the last cell in the vector, so we need to iterate backwards
-	for (size_t j = pCell->state.spring_attachments.size(); j-- > 0; )
+	for (size_t j = spring_attachments_snapshot.size(); j-- > 0; )
     {
-        Cell* pTest = pCell->state.spring_attachments[j];
+        Cell* pTest = spring_attachments_snapshot[j];
 		if (phenotype.cell_interactions.pAttackTarget==pTest || pTest->phenotype.cell_interactions.pAttackTarget==pCell) // do not let attackers detach randomly
 		{ continue; }
         if( UniformRandom() <= detachment_probability )


### PR DESCRIPTION
`dynamic_spring_attachments()` runs inside the mechanics parallel-for and walks `pCell->state.spring_attachments` with **no lock**. That vector is not private to the thread: another thread running the same function for a neighbouring cell calls `attach_cells_as_spring()`, which reaches into *this* cell's `spring_attachments` and `push_back()`s.

Those writers serialize on the unnamed `critical` inside `Cell::attach_cell_as_spring()` / `Cell::detach_cell_as_spring()`. The read did not take it. A concurrent `push_back` that reallocates leaves the loop indexing a freed buffer, and the next iteration dereferences whatever it finds.

## Symptom

Intermittent `SIGSEGV`, thread-count dependent, therefore invisible on single-threaded runs.

This is a macOS crash report (`~/Library/Logs/DiagnosticReports/*.ips`) from a local reproduction of the fault, reformatted from the JSON into the familiar layout but otherwise verbatim — one report, not a composite:

```
Exception Type:  EXC_BAD_ACCESS (SIGSEGV)
Exception Codes: KERN_INVALID_ADDRESS at 0xa25ac1f1a87354d7

Thread 24113875 Crashed:
0  bin_base3      PhysiCell::dynamic_spring_attachments(PhysiCell::Cell*, PhysiCell::Phenotype&, double) + 352688
1  bin_base3      PhysiCell::Cell_Container::update_all_cells(double, double, double, double) (.omp_outlined_debug__.15) + 331176
2  bin_base3      PhysiCell::Cell_Container::update_all_cells(double, double, double, double) (.omp_outlined.16) + 331176
3  libomp.dylib   __kmp_invoke_microtask + 449836
4  ???            ??? + 1
```

The faulting address is not a null and not a plausible heap pointer: it is a torn `Cell*` read out of a vector buffer that another thread reallocated mid-loop. Across 25 collected reports the top four frames are identical every time, and the address is garbage every time — sometimes wild (`0xf2c16c8da6e8ff31`), sometimes a small plausible-looking value (`0x00000000002b01f5`).

On Linux this surfaces differently: no `.ips`, just the scheduler reporting the job as failed, which is how it was first seen on an HPC cluster.

## Change

Copy the vector under the same critical the writers use, then walk the copy. One hunk, one file.

The lock is deliberately **not** held across the loop body: `detach_cells_as_spring()` takes the same unnamed critical, and OpenMP criticals are not reentrant — holding it would deadlock.

## Evidence

Reproduced on a user model that faults reliably. 60 runs per arm, 4 threads, `-O3`:

| arm | n | crashes |
|---|---|---|
| baseline | 60 | **10 (16.7%)** |
| this change | 60 | **0** |
| baseline, 1 thread | 30 | 0 |

Cost: **+2.4%** wall time — paired median ratio 1.0237, slower in 9 of 9 paired blocks, and independently 1.0237 in a separate campaign.

## Scope

This fixes the crash, and only the crash. Two things are deliberately left alone:

- The attachment half still reads `.size()` outside the lock (three places), so the function is **not** data-race-free. It is crash-free. TSan will still flag it.
- `attach_cells_as_spring()` / `detach_cells_as_spring()` each take the critical twice, once per cell, so a pair operation is not atomic. An interleaving can leave a one-way spring — A pulls toward B while B feels nothing, since `standard_elastic_contact_function` applies force to `pC1` only. I verified this occurs (instrumented symmetry audit, ~12% of mechanics steps on a model with non-zero `detachment_rate`, self-healing after ~10 steps). It is a distinct bug with a distinct fix and does not belong in this change.

Neither is a regression; both predate this patch.

