### PR TITLE
Add a weighted mode for asymmetric division

### DIFF
--- a/core/PhysiCell_phenotype.cpp
+++ b/core/PhysiCell_phenotype.cpp
@@ -1450,9 +1450,11 @@ double Asymmetric_Division::asymmetric_division_probability( std::string type_na
 	return asymmetric_division_probability(n, m);
 }
 
-std::pair<int, int> Asymmetric_Division::select_daughter_types(int type_1, int type_2)
+std::pair<int, int> Asymmetric_Division::select_daughter_types(int type_1, int type_2, double total_weight)
 {
-	double r = UniformRandom();
+	// total_weight == 1.0 leaves this exactly as it was before weights existed: multiplying a double
+	// by 1.0 is exact, so a model reading these as probabilities draws the same numbers as ever.
+	double r = UniformRandom() * total_weight;
 	double cumulative = 0.0;
 	for( auto it = asymmetric_division_probabilities.begin(); it != asymmetric_division_probabilities.end(); ++it )
 	{

--- a/core/PhysiCell_phenotype.h
+++ b/core/PhysiCell_phenotype.h
@@ -255,8 +255,10 @@ public:
 	double probabilities_total( void );
 
 
-
-	std::pair<int, int> select_daughter_types(int type_1, int type_2);
+	// total_weight scales the draw. Leave it at 1.0 and the stored values are read as absolute
+	// probabilities, so whatever they leave short of 1 falls through to symmetric division; pass the
+	// map's own total and they are read as relative weights, normalized by that total.
+	std::pair<int, int> select_daughter_types(int type_1, int type_2, double total_weight = 1.0);
 };
 
 std::pair<int, int> extended_asym_index_to_upper_triangle(int index);

--- a/core/PhysiCell_standard_models.cpp
+++ b/core/PhysiCell_standard_models.cpp
@@ -1324,37 +1324,57 @@ void asymmetric_division_function( Cell* pCell_parent, Cell* pCell_daughter )
 	std::string parent_name = pCell_parent->type_name;
 	int parent_type = pCell_parent->type;
 	Asymmetric_Division& parent_asym_div = pCell_parent->phenotype.cycle.asymmetric_division;
-	// The tolerance decides only whether an overshoot is an error, never whether the probabilities
-	// get adjusted: this block rewrites the symmetric division probability, so gating entry on a
-	// user-settable threshold would let the tolerance change the model rather than just its strictness.
-	const double tolerance = PhysiCell_settings.asymmetric_division_probability_tolerance;
 	double total = parent_asym_div.probabilities_total();
-	if (total > 1.0)
+
+	// The daughter pair is drawn from [0, total_weight). Left at 1.0 the stored values are absolute
+	// probabilities and whatever they leave short of 1 falls through to symmetric division; set to the
+	// map's own total they are relative weights, normalized by that total.
+	double total_weight = 1.0;
+
+	if (PhysiCell_settings.asymmetric_division_uses_weights)
 	{
-		double sym_div_prob = parent_asym_div.asymmetric_division_probability(parent_type, parent_type) + 1.0 - total;
-		// probabilities meant to sum to exactly 1 land a hair over it in double precision:
-		// 0.11 + 0.33 + 0.56 is 1.000000000000000222. How much slack a model needs depends on how
-		// many probabilities it sums and how they are computed, hence the configurable tolerance.
-		if (sym_div_prob < -tolerance)
+		// An all-zero total has no normalized distribution. By convention that is symmetric division,
+		// which is what leaving total_weight at 1.0 gets: the running total never passes the draw, so
+		// select_daughter_types falls through to the parent and daughter types unchanged.
+		if (total > 0.0)
+		{ total_weight = total; }
+	}
+	else
+	{
+		// The tolerance decides only whether an overshoot is an error, never whether the
+		// probabilities get adjusted: this block rewrites the symmetric division probability, so
+		// gating entry on a user-settable threshold would let the tolerance change the model rather
+		// than just its strictness.
+		const double tolerance = PhysiCell_settings.asymmetric_division_probability_tolerance;
+		if (total > 1.0)
 		{
-			std::cerr << "Error: Asymmetric division probabilities for " + parent_name + " sum to greater than 1.0 and cannot be normalized." << std::endl;
-			std::cerr << "Adjusted sym_div_prob = " << sym_div_prob << std::endl;
-			std::cerr << "List of all asym div probabilities for this cell:" << std::endl;
-			for (auto& entry : parent_asym_div.asymmetric_division_probabilities)
+			double sym_div_prob = parent_asym_div.asymmetric_division_probability(parent_type, parent_type) + 1.0 - total;
+			// probabilities meant to sum to exactly 1 land a hair over it in double precision:
+			// 0.11 + 0.33 + 0.56 is 1.000000000000000222. How much slack a model needs depends on how
+			// many probabilities it sums and how they are computed, hence the configurable tolerance.
+			if (sym_div_prob < -tolerance)
 			{
-				std::cerr << "  - " << cell_definitions_by_index[entry.first.first]->name
-					<< " and " << cell_definitions_by_index[entry.first.second]->name
-					<< ": " << entry.second << std::endl;
+				std::cerr << "Error: Asymmetric division probabilities for " + parent_name + " sum to greater than 1.0 and cannot be normalized." << std::endl;
+				std::cerr << "Adjusted sym_div_prob = " << sym_div_prob << std::endl;
+				std::cerr << "List of all asym div probabilities for this cell:" << std::endl;
+				for (auto& entry : parent_asym_div.asymmetric_division_probabilities)
+				{
+					std::cerr << "  - " << cell_definitions_by_index[entry.first.first]->name
+						<< " and " << cell_definitions_by_index[entry.first.second]->name
+						<< ": " << entry.second << std::endl;
+				}
+				std::cerr << "If these are meant as relative weights rather than probabilities, set" << std::endl
+					<< "<asymmetric_division_mode>weights</asymmetric_division_mode> in the <options> block." << std::endl;
+				exit(-1);
 			}
-			exit(-1);
+			if (sym_div_prob < 0.0)
+			{ sym_div_prob = 0.0; } // round-off only, given the check above
+			parent_asym_div.set_asymmetric_division_probability(parent_type, parent_type, sym_div_prob);
+			pCell_daughter->phenotype.cycle.asymmetric_division.set_asymmetric_division_probability(pCell_daughter->type, pCell_daughter->type, sym_div_prob);
 		}
-		if (sym_div_prob < 0.0)
-		{ sym_div_prob = 0.0; } // round-off only, given the check above
-		parent_asym_div.set_asymmetric_division_probability(parent_type, parent_type, sym_div_prob);
-		pCell_daughter->phenotype.cycle.asymmetric_division.set_asymmetric_division_probability(pCell_daughter->type, pCell_daughter->type, sym_div_prob);
 	}
 
-	std::pair<int, int> daughter_types = parent_asym_div.select_daughter_types(pCell_parent->type, pCell_daughter->type);
+	std::pair<int, int> daughter_types = parent_asym_div.select_daughter_types(pCell_parent->type, pCell_daughter->type, total_weight);
 
 	if (daughter_types.first != pCell_parent->type) // only convert if the parent is not already the correct type
 	{ pCell_parent->convert_to_cell_definition( *cell_definitions_by_index[daughter_types.first] ); }

--- a/core/PhysiCell_standard_models.cpp
+++ b/core/PhysiCell_standard_models.cpp
@@ -1324,14 +1324,17 @@ void asymmetric_division_function( Cell* pCell_parent, Cell* pCell_daughter )
 	std::string parent_name = pCell_parent->type_name;
 	int parent_type = pCell_parent->type;
 	Asymmetric_Division& parent_asym_div = pCell_parent->phenotype.cycle.asymmetric_division;
-	// probabilities meant to sum to exactly 1 land a hair over it in double precision:
-	// 0.11 + 0.33 + 0.56 is 1.000000000000000222. Configurable because how much slack a model
-	// needs depends on how many probabilities it sums and how they are computed.
+	// The tolerance decides only whether an overshoot is an error, never whether the probabilities
+	// get adjusted: this block rewrites the symmetric division probability, so gating entry on a
+	// user-settable threshold would let the tolerance change the model rather than just its strictness.
 	const double tolerance = PhysiCell_settings.asymmetric_division_probability_tolerance;
 	double total = parent_asym_div.probabilities_total();
-	if (total > 1.0 + tolerance)
+	if (total > 1.0)
 	{
 		double sym_div_prob = parent_asym_div.asymmetric_division_probability(parent_type, parent_type) + 1.0 - total;
+		// probabilities meant to sum to exactly 1 land a hair over it in double precision:
+		// 0.11 + 0.33 + 0.56 is 1.000000000000000222. How much slack a model needs depends on how
+		// many probabilities it sums and how they are computed, hence the configurable tolerance.
 		if (sym_div_prob < -tolerance)
 		{
 			std::cerr << "Error: Asymmetric division probabilities for " + parent_name + " sum to greater than 1.0 and cannot be normalized." << std::endl;

--- a/modules/PhysiCell_settings.cpp
+++ b/modules/PhysiCell_settings.cpp
@@ -334,8 +334,40 @@ void PhysiCell_Settings::read_from_pugixml( void )
 			PhysiCell_settings.disable_automated_spring_adhesions = true;
 		}
 
+		// Read the asymmetric division mode before the tolerance so the tolerance can reject the
+		// combination: the two options answer the same question in incompatible ways.
+		pugi::xml_node node_asym_div_mode = node_options.child( "asymmetric_division_mode" );
+		if( node_asym_div_mode )
+		{
+			std::string mode = xml_get_my_string_value( node_asym_div_mode );
+			if( mode == "weights" )
+			{
+				PhysiCell_settings.asymmetric_division_uses_weights = true;
+				std::cout << "Using weights for asymmetric division: the values set per cell type are relative weights," << std::endl
+					<< "\tnormalized by their sum at each division, not probabilities." << std::endl
+					<< "\tSymmetric division is not the leftover of 1 here; give it its own weight if you want it." << std::endl;
+			}
+			else if( mode != "probabilities" )
+			{
+				// A string rather than a bool so a typo lands here instead of quietly reading as false
+				// and running the model in the other mode.
+				std::cerr << "Error: <asymmetric_division_mode> is \"" << mode
+					<< "\", but it must be either \"probabilities\" or \"weights\"." << std::endl;
+				exit(-1);
+			}
+		}
+
 		if( node_options.child( "asymmetric_division_probability_tolerance" ) )
 		{
+			if( PhysiCell_settings.asymmetric_division_uses_weights )
+			{
+				std::cerr << "Error: <asymmetric_division_probability_tolerance> cannot be set together with" << std::endl
+					<< "\t<asymmetric_division_mode>weights</asymmetric_division_mode>." << std::endl
+					<< "\tThe tolerance bounds how far asymmetric division probabilities may sum past 1." << std::endl
+					<< "\tWeights are normalized by their own sum instead of being bounded, so there is nothing" << std::endl
+					<< "\tfor the tolerance to do. Remove whichever of the two you did not mean." << std::endl;
+				exit(-1);
+			}
 			double tol = xml_get_double_value( node_options, "asymmetric_division_probability_tolerance" );
 			if( tol < 0.0 )
 			{

--- a/modules/PhysiCell_settings.h
+++ b/modules/PhysiCell_settings.h
@@ -121,8 +121,21 @@ class PhysiCell_Settings
 	// slack allowed when checking that asymmetric division probabilities sum to at most 1.
 	// Probabilities meant to sum to exactly 1 land a hair over it in double precision:
 	// 0.11 + 0.33 + 0.56 is 1.000000000000000222. Override with <asymmetric_division_probability_tolerance>
-	// in the <options> block.
+	// in the <options> block. Only meaningful when the values are probabilities; see below.
 	double asymmetric_division_probability_tolerance = 1e-12;
+
+	// How the values in Asymmetric_Division::asymmetric_division_probabilities are read, model-wide.
+	// false (default): they are probabilities. They must sum to at most 1 (up to the tolerance above),
+	//   and whatever is left of 1 is the probability of dividing symmetrically.
+	// true: they are relative weights, normalized by their own sum at each division, so their scale
+	//   does not matter -- which is what lets rules move each daughter-type pair independently without
+	//   any rule needing to know what the others currently evaluate to. There is no implicit symmetric
+	//   division remainder under weights: symmetric division needs its own (type,type) weight. The one
+	//   exception is an all-zero total, which has no normalized distribution and is defined as
+	//   symmetric division.
+	// Set with <asymmetric_division_mode> in the <options> block. Mutually exclusive with
+	// <asymmetric_division_probability_tolerance>, which has nothing to bound once values are normalized.
+	bool asymmetric_division_uses_weights = false;
 	
 	double SVG_save_interval = 60;
 	bool enable_SVG_saves = true;

--- a/sample_projects/extended_asym_div/README.md
+++ b/sample_projects/extended_asym_div/README.md
@@ -1,0 +1,64 @@
+# Extended asymmetric division sample
+
+A single `type0` cell divides in a 2-D domain. Which pair of daughter types each division produces is
+set per unordered pair under `<extended_asymmetric_division>` in the config, and driven over time by
+the rules file. Only `type0` divides, so every division is one of three outcomes: it stays `type0`, or
+it produces `type1` and `type2`, or `type3` and `type4`.
+
+## Two configs, two ways of writing the same model
+
+```bash
+./project ./config/PhysiCell_settings.xml          # -> output/
+./project ./config/PhysiCell_settings_weights.xml  # -> output_weights/
+```
+
+`PhysiCell_settings_weights.xml` is `PhysiCell_settings.xml` with three changes: the output folder,
+`<asymmetric_division_mode>weights</asymmetric_division_mode>` in the `<options>` block, and
+[cell_rules_weights.csv](config/cell_rules_weights.csv) in place of
+[cell_rules.csv](config/cell_rules.csv). The rules differ only in their saturation values:
+
+| | `(type0, type0)` | `(type1, type2)`, then `(type3, type4)` | what the code does with them |
+|---|---|---|---|
+| `probabilities` | 1.0 | saturates at **0.5** | total is 1.5, so the 0.5 excess comes **entirely out of** `(type0, type0)`, leaving 0.5 and 0.5 |
+| `weights` | 1.0 | saturates at **1.0** | total is 2.0, and **every** entry is scaled by 1/2.0, leaving 0.5 and 0.5 |
+
+Both land on the same 50/50 split, and the two runs are the same simulation — same cells, same
+positions, same types, at every snapshot. What differs is only the recorded values: `(type0, type0)`
+reads 0.5 in one and 1.0 in the other, because weights are a re-parameterization, not a different
+model.
+
+That table is also the thing to understand before switching an existing model over. The two modes
+renormalize differently, and the difference is not subtle: **probabilities take the whole overshoot
+out of the symmetric entry, while weights scale every entry proportionally.** Feed this sample's
+probabilities config to weights mode unchanged and `(type0, type0)` gets 1.0/1.5 = 2/3 of divisions
+instead of 1/2. Same numbers, different model. That is why setting
+`<asymmetric_division_probability_tolerance>` together with weights is rejected at startup rather than
+one of the two quietly winning.
+
+## Writing a model in weights mode
+
+Weights exist so that rules can move each daughter-type pair independently. Under probabilities every
+rule has to cooperate to keep the total at or below 1, which no single rule can check, because a
+Hypothesis Grammar rule cannot see what the other pairs currently evaluate to. Under weights the scale
+does not matter, so each rule can be written on its own.
+
+The pitfall worth knowing: **under weights there is no implicit symmetric-division remainder.** In
+probabilities mode a cell type listing only `(type0, type1): 0.3` divides symmetrically the other 70%
+of the time. In weights mode that same cell divides into `type0` and `type1` every single time, because
+that is the only pair carrying any weight. Self-renewal needs its own `(type0, type0)` weight, which is
+exactly what this sample gives it.
+
+The one exception is an all-zero total, which has no normalized distribution: that is defined as
+symmetric division, so a model whose weights start at zero and ramp up through rules divides
+symmetrically at first rather than failing.
+
+## Building
+
+```bash
+make extended-asym-div-sample && make
+```
+
+A note on reproducibility if you compare runs: with `<omp_num_threads>` above 1 this model is not
+bit-reproducible from the seed alone, and because the `type0` population is close to a critical
+branching process the run-to-run spread in final cell count is large. Set `<omp_num_threads>1</omp_num_threads>`
+in both configs to compare them directly.

--- a/sample_projects/extended_asym_div/config/PhysiCell_settings_weights.xml
+++ b/sample_projects/extended_asym_div/config/PhysiCell_settings_weights.xml
@@ -1,0 +1,819 @@
+<PhysiCell_settings version="devel-version">
+
+    <domain>
+        <x_min>-500</x_min>
+        <x_max>500</x_max>
+        <y_min>-500</y_min>
+        <y_max>500</y_max>
+        <z_min>-10</z_min>
+        <z_max>10</z_max>
+        <dx>20</dx>
+        <dy>20</dy>
+        <dz>20</dz>
+        <use_2D>true</use_2D>
+    </domain>
+
+    <overall>
+        <max_time units="min">7200</max_time>
+        <time_units>min</time_units>
+        <space_units>micron</space_units>
+        <dt_diffusion units="min">0.01</dt_diffusion>
+        <dt_mechanics units="min">0.1</dt_mechanics>
+        <dt_phenotype units="min">6</dt_phenotype>
+    </overall>
+
+    <parallel>
+        <omp_num_threads>6</omp_num_threads>
+    </parallel>
+
+    <save>
+        <folder>output_weights</folder>
+        <full_data>
+            <interval units="min">60</interval>
+            <enable>true</enable>
+        </full_data>
+        <SVG>
+            <interval units="min">60</interval>
+            <enable>true</enable>
+            <plot_substrate enabled="false" limits="true">
+                <substrate>substrate</substrate>
+                <colormap>YlOrRd</colormap>
+                <min_conc>0</min_conc>
+                <max_conc>1</max_conc>
+            </plot_substrate>
+            <!-- Optional: override SVG colors for specific cell types.
+                 Names must match cell_definition names exactly; an unrecognized name is an error.
+                 Partial coverage is fine: unlisted cell types are assigned colors automatically
+                 from the built-in palette (with any user-claimed colors skipped), then generated
+                 via golden-angle HSV spacing once the palette is exhausted.
+                 If this element is absent entirely, all colors are assigned automatically.
+                 Accepted color formats: CSS named colors (e.g. "red"), #rrggbb/#rgb hex, rgb(r,g,b).
+            <cell_colors>
+                <cell_color name="cancer cell">red</cell_color>
+                <cell_color name="immune cell">cyan</cell_color>
+            </cell_colors>
+            -->
+        </SVG>
+        <legacy_data>
+            <enable>false</enable>
+        </legacy_data>
+    </save>
+
+    <options>
+        <legacy_random_points_on_sphere_in_divide>false</legacy_random_points_on_sphere_in_divide>
+        <virtual_wall_at_domain_edge>true</virtual_wall_at_domain_edge>
+        <disable_automated_spring_adhesions>false</disable_automated_spring_adhesions>
+        <!-- Read every extended_asymmetric_division_probability below, and every value the rules
+             write into them, as a relative weight rather than a probability: at each division they
+             are normalized by their own sum instead of being required to sum to at most 1. Symmetric
+             division is not the leftover of 1 under weights, which is why type0 carries an explicit
+             (type0, type0) weight of its own.
+             This file is PhysiCell_settings.xml with three changes: this element, the output folder,
+             and cell_rules_weights.csv in place of cell_rules.csv. The rules differ only in their
+             saturation values, chosen so the normalized weights reproduce this model's probabilities
+             exactly -- the two configs are the same model written two ways. See README.md. -->
+        <asymmetric_division_mode>weights</asymmetric_division_mode>
+        <random_seed>0</random_seed>
+    </options>
+
+    <microenvironment_setup>
+        <variable name="substrate" units="dimensionless" ID="0">
+            <physical_parameter_set>
+                <diffusion_coefficient units="micron^2/min">100000.0</diffusion_coefficient>
+                <decay_rate units="1/min">10</decay_rate>
+            </physical_parameter_set>
+            <initial_condition units="mmHg">0</initial_condition>
+            <Dirichlet_boundary_condition units="mmHg" enabled="False">0</Dirichlet_boundary_condition>
+            <Dirichlet_options>
+                <boundary_value ID="xmin" enabled="False">0</boundary_value>
+                <boundary_value ID="xmax" enabled="False">0</boundary_value>
+                <boundary_value ID="ymin" enabled="False">0</boundary_value>
+                <boundary_value ID="ymax" enabled="False">0</boundary_value>
+                <boundary_value ID="zmin" enabled="False">0</boundary_value>
+                <boundary_value ID="zmax" enabled="False">0</boundary_value>
+            </Dirichlet_options>
+        </variable>
+        <options>
+            <calculate_gradients>true</calculate_gradients>
+            <track_internalized_substrates_in_each_agent>true</track_internalized_substrates_in_each_agent>
+            <initial_condition type="matlab" enabled="false">
+                <filename>./config/initial.mat</filename>
+            </initial_condition>
+            <dirichlet_nodes type="matlab" enabled="false">
+                <filename>./config/dirichlet.mat</filename>
+            </dirichlet_nodes>
+        </options>
+    </microenvironment_setup>
+
+    <cell_definitions>
+        <cell_definition name="type0" ID="0">
+            <phenotype>
+                <cycle code="5" name="live">
+                    <phase_transition_rates units="1/min">
+                        <rate start_index="0" end_index="0" fixed_duration="true">0.005</rate>
+                    </phase_transition_rates>
+                    <extended_asymmetric_division enabled="True">
+                        <extended_asymmetric_division_probability name1="type0" name2="type0" units="dimensionless">1.0</extended_asymmetric_division_probability>
+                    </extended_asymmetric_division>
+                </cycle>
+                <death>
+                    <model code="100" name="apoptosis">
+                        <death_rate units="1/min">0</death_rate>
+                        <phase_durations units="min">
+                            <duration index="0" fixed_duration="true">516</duration>
+                        </phase_durations>
+                        <parameters>
+                            <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                            <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                            <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                            <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                            <calcification_rate units="1/min">0</calcification_rate>
+                            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                        </parameters>
+                    </model>
+                    <model code="101" name="necrosis">
+                        <death_rate units="1/min">0.0</death_rate>
+                        <phase_durations units="min">
+                            <duration index="0" fixed_duration="true">0</duration>
+                            <duration index="1" fixed_duration="true">86400</duration>
+                        </phase_durations>
+                        <parameters>
+                            <unlysed_fluid_change_rate units="1/min">1.11667e-2</unlysed_fluid_change_rate>
+                            <lysed_fluid_change_rate units="1/min">8.33333e-4</lysed_fluid_change_rate>
+                            <cytoplasmic_biomass_change_rate units="1/min">5.33333e-5</cytoplasmic_biomass_change_rate>
+                            <nuclear_biomass_change_rate units="1/min">2.16667e-3</nuclear_biomass_change_rate>
+                            <calcification_rate units="1/min">0</calcification_rate>
+                            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                        </parameters>
+                    </model>
+                </death>
+                <volume>
+                    <total units="micron^3">2494</total>
+                    <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+                    <nuclear units="micron^3">540</nuclear>
+                    <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+                    <calcified_fraction units="dimensionless">0</calcified_fraction>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </volume>
+                <mechanics>
+                    <cell_cell_adhesion_strength units="micron/min">0.4</cell_cell_adhesion_strength>
+                    <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+                    <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+                    <cell_adhesion_affinities>
+                        <cell_adhesion_affinity name="default">1</cell_adhesion_affinity>
+                    </cell_adhesion_affinities>
+                    <options>
+                        <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                        <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+                    </options>
+                    <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+                    <attachment_rate units="1/min">0.0</attachment_rate>
+                    <detachment_rate units="1/min">0.0</detachment_rate>
+                    <maximum_number_of_attachments>12</maximum_number_of_attachments>
+                </mechanics>
+                <motility>
+                    <speed units="micron/min">1</speed>
+                    <persistence_time units="min">1</persistence_time>
+                    <migration_bias units="dimensionless">.5</migration_bias>
+                    <options>
+                        <enabled>false</enabled>
+                        <use_2D>true</use_2D>
+                        <chemotaxis>
+                            <enabled>false</enabled>
+                            <substrate>substrate</substrate>
+                            <direction>1</direction>
+                        </chemotaxis>
+                        <advanced_chemotaxis>
+                            <enabled>false</enabled>
+                            <normalize_each_gradient>false</normalize_each_gradient>
+                            <chemotactic_sensitivities>
+                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
+                            </chemotactic_sensitivities>
+                        </advanced_chemotaxis>
+                    </options>
+                </motility>
+                <secretion>
+                    <substrate name="substrate">
+                        <secretion_rate units="1/min">0</secretion_rate>
+                        <secretion_target units="substrate density">1</secretion_target>
+                        <uptake_rate units="1/min">0</uptake_rate>
+                        <net_export_rate units="total substrate/min">0</net_export_rate>
+                    </substrate>
+                </secretion>
+                <cell_interactions>
+                    <apoptotic_phagocytosis_rate units="1/min">0</apoptotic_phagocytosis_rate>
+                    <necrotic_phagocytosis_rate units="1/min">0</necrotic_phagocytosis_rate>
+                    <other_dead_phagocytosis_rate units="1/min">0</other_dead_phagocytosis_rate>
+                    <live_phagocytosis_rates>
+                        <phagocytosis_rate name="default" units="1/min">0</phagocytosis_rate>
+                    </live_phagocytosis_rates>
+                    <attack_rates>
+                        <attack_rate name="default" units="1/min">0</attack_rate>
+                    </attack_rates>
+                    <attack_damage_rate units="1/min">1</attack_damage_rate>
+                    <attack_duration units="min">0.1</attack_duration>
+                    <fusion_rates>
+                        <fusion_rate name="default" units="1/min">0</fusion_rate>
+                    </fusion_rates>
+                </cell_interactions>
+                <cell_transformations>
+                    <transformation_rates>
+                        <transformation_rate name="default" units="1/min">0</transformation_rate>
+                    </transformation_rates>
+                </cell_transformations>
+                <cell_integrity>
+                    <damage_rate units="1/min">0.0</damage_rate>
+                    <damage_repair_rate units="1/min">0.0</damage_repair_rate>
+                </cell_integrity>
+            </phenotype>
+            <custom_data>
+                <sample conserved="false" units="dimensionless" description="">1.0</sample>
+            </custom_data>
+            <initial_parameter_distributions enabled="false">
+                <distribution enabled="false" type="Log10Normal" check_base="true">
+                    <behavior>Volume</behavior>
+                    <mu>4</mu>
+                    <sigma>2</sigma>
+                    <upper_bound>100000</upper_bound>
+                </distribution>
+                <distribution enabled="false" type="LogUniform" check_base="true">
+                    <behavior>apoptosis</behavior>
+                    <min>1e-6</min>
+                    <max>1e-2</max>
+                </distribution>
+            </initial_parameter_distributions>
+        </cell_definition>
+        <cell_definition name="type1" ID="1">
+            <phenotype>
+                <cycle code="5" name="live">
+                    <phase_transition_rates units="1/min">
+                        <rate start_index="0" end_index="0" fixed_duration="false">0.0</rate>
+                    </phase_transition_rates>
+                </cycle>
+                <death>
+                    <model code="100" name="apoptosis">
+                        <death_rate units="1/min">0</death_rate>
+                        <phase_durations units="min">
+                            <duration index="0" fixed_duration="true">516</duration>
+                        </phase_durations>
+                        <parameters>
+                            <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                            <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                            <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                            <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                            <calcification_rate units="1/min">0</calcification_rate>
+                            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                        </parameters>
+                    </model>
+                    <model code="101" name="necrosis">
+                        <death_rate units="1/min">0.0</death_rate>
+                        <phase_durations units="min">
+                            <duration index="0" fixed_duration="true">0</duration>
+                            <duration index="1" fixed_duration="true">86400</duration>
+                        </phase_durations>
+                        <parameters>
+                            <unlysed_fluid_change_rate units="1/min">1.11667e-2</unlysed_fluid_change_rate>
+                            <lysed_fluid_change_rate units="1/min">8.33333e-4</lysed_fluid_change_rate>
+                            <cytoplasmic_biomass_change_rate units="1/min">5.33333e-5</cytoplasmic_biomass_change_rate>
+                            <nuclear_biomass_change_rate units="1/min">2.16667e-3</nuclear_biomass_change_rate>
+                            <calcification_rate units="1/min">0</calcification_rate>
+                            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                        </parameters>
+                    </model>
+                </death>
+                <volume>
+                    <total units="micron^3">2494</total>
+                    <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+                    <nuclear units="micron^3">540</nuclear>
+                    <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+                    <calcified_fraction units="dimensionless">0</calcified_fraction>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </volume>
+                <mechanics>
+                    <cell_cell_adhesion_strength units="micron/min">0.4</cell_cell_adhesion_strength>
+                    <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+                    <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+                    <cell_adhesion_affinities>
+                        <cell_adhesion_affinity name="default">1</cell_adhesion_affinity>
+                    </cell_adhesion_affinities>
+                    <options>
+                        <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                        <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+                    </options>
+                    <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+                    <attachment_rate units="1/min">0.0</attachment_rate>
+                    <detachment_rate units="1/min">0.0</detachment_rate>
+                    <maximum_number_of_attachments>12</maximum_number_of_attachments>
+                </mechanics>
+                <motility>
+                    <speed units="micron/min">1</speed>
+                    <persistence_time units="min">1</persistence_time>
+                    <migration_bias units="dimensionless">.5</migration_bias>
+                    <options>
+                        <enabled>false</enabled>
+                        <use_2D>true</use_2D>
+                        <chemotaxis>
+                            <enabled>false</enabled>
+                            <substrate>substrate</substrate>
+                            <direction>1</direction>
+                        </chemotaxis>
+                        <advanced_chemotaxis>
+                            <enabled>false</enabled>
+                            <normalize_each_gradient>false</normalize_each_gradient>
+                            <chemotactic_sensitivities>
+                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
+                            </chemotactic_sensitivities>
+                        </advanced_chemotaxis>
+                    </options>
+                </motility>
+                <secretion>
+                    <substrate name="substrate">
+                        <secretion_rate units="1/min">0</secretion_rate>
+                        <secretion_target units="substrate density">1</secretion_target>
+                        <uptake_rate units="1/min">0</uptake_rate>
+                        <net_export_rate units="total substrate/min">0</net_export_rate>
+                    </substrate>
+                </secretion>
+                <cell_interactions>
+                    <apoptotic_phagocytosis_rate units="1/min">0</apoptotic_phagocytosis_rate>
+                    <necrotic_phagocytosis_rate units="1/min">0</necrotic_phagocytosis_rate>
+                    <other_dead_phagocytosis_rate units="1/min">0</other_dead_phagocytosis_rate>
+                    <live_phagocytosis_rates>
+                        <phagocytosis_rate name="default" units="1/min">0</phagocytosis_rate>
+                    </live_phagocytosis_rates>
+                    <attack_rates>
+                        <attack_rate name="default" units="1/min">0</attack_rate>
+                    </attack_rates>
+                    <attack_damage_rate units="1/min">1</attack_damage_rate>
+                    <attack_duration units="min">0.1</attack_duration>
+                    <fusion_rates>
+                        <fusion_rate name="default" units="1/min">0</fusion_rate>
+                    </fusion_rates>
+                </cell_interactions>
+                <cell_transformations>
+                    <transformation_rates>
+                        <transformation_rate name="default" units="1/min">0</transformation_rate>
+                    </transformation_rates>
+                </cell_transformations>
+                <cell_integrity>
+                    <damage_rate units="1/min">0.0</damage_rate>
+                    <damage_repair_rate units="1/min">0.0</damage_repair_rate>
+                </cell_integrity>
+            </phenotype>
+            <custom_data>
+                <sample conserved="false" units="dimensionless" description="">1.0</sample>
+            </custom_data>
+            <initial_parameter_distributions enabled="false">
+                <distribution enabled="false" type="Log10Normal" check_base="true">
+                    <behavior>Volume</behavior>
+                    <mu>4</mu>
+                    <sigma>2</sigma>
+                    <upper_bound>100000</upper_bound>
+                </distribution>
+                <distribution enabled="false" type="LogUniform" check_base="true">
+                    <behavior>apoptosis</behavior>
+                    <min>1e-6</min>
+                    <max>1e-2</max>
+                </distribution>
+            </initial_parameter_distributions>
+        </cell_definition>
+        <cell_definition name="type2" ID="2">
+            <phenotype>
+                <cycle code="5" name="live">
+                    <phase_transition_rates units="1/min">
+                        <rate start_index="0" end_index="0" fixed_duration="false">0</rate>
+                    </phase_transition_rates>
+                </cycle>
+                <death>
+                    <model code="100" name="apoptosis">
+                        <death_rate units="1/min">0</death_rate>
+                        <phase_durations units="min">
+                            <duration index="0" fixed_duration="true">516</duration>
+                        </phase_durations>
+                        <parameters>
+                            <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                            <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                            <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                            <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                            <calcification_rate units="1/min">0</calcification_rate>
+                            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                        </parameters>
+                    </model>
+                    <model code="101" name="necrosis">
+                        <death_rate units="1/min">0.0</death_rate>
+                        <phase_durations units="min">
+                            <duration index="0" fixed_duration="true">0</duration>
+                            <duration index="1" fixed_duration="true">86400</duration>
+                        </phase_durations>
+                        <parameters>
+                            <unlysed_fluid_change_rate units="1/min">1.11667e-2</unlysed_fluid_change_rate>
+                            <lysed_fluid_change_rate units="1/min">8.33333e-4</lysed_fluid_change_rate>
+                            <cytoplasmic_biomass_change_rate units="1/min">5.33333e-5</cytoplasmic_biomass_change_rate>
+                            <nuclear_biomass_change_rate units="1/min">2.16667e-3</nuclear_biomass_change_rate>
+                            <calcification_rate units="1/min">0</calcification_rate>
+                            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                        </parameters>
+                    </model>
+                </death>
+                <volume>
+                    <total units="micron^3">2494</total>
+                    <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+                    <nuclear units="micron^3">540</nuclear>
+                    <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+                    <calcified_fraction units="dimensionless">0</calcified_fraction>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </volume>
+                <mechanics>
+                    <cell_cell_adhesion_strength units="micron/min">0.4</cell_cell_adhesion_strength>
+                    <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+                    <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+                    <cell_adhesion_affinities>
+                        <cell_adhesion_affinity name="default">1</cell_adhesion_affinity>
+                    </cell_adhesion_affinities>
+                    <options>
+                        <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                        <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+                    </options>
+                    <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+                    <attachment_rate units="1/min">0.0</attachment_rate>
+                    <detachment_rate units="1/min">0.0</detachment_rate>
+                    <maximum_number_of_attachments>12</maximum_number_of_attachments>
+                </mechanics>
+                <motility>
+                    <speed units="micron/min">1</speed>
+                    <persistence_time units="min">1</persistence_time>
+                    <migration_bias units="dimensionless">.5</migration_bias>
+                    <options>
+                        <enabled>false</enabled>
+                        <use_2D>true</use_2D>
+                        <chemotaxis>
+                            <enabled>false</enabled>
+                            <substrate>substrate</substrate>
+                            <direction>1</direction>
+                        </chemotaxis>
+                        <advanced_chemotaxis>
+                            <enabled>false</enabled>
+                            <normalize_each_gradient>false</normalize_each_gradient>
+                            <chemotactic_sensitivities>
+                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
+                            </chemotactic_sensitivities>
+                        </advanced_chemotaxis>
+                    </options>
+                </motility>
+                <secretion>
+                    <substrate name="substrate">
+                        <secretion_rate units="1/min">0</secretion_rate>
+                        <secretion_target units="substrate density">1</secretion_target>
+                        <uptake_rate units="1/min">0</uptake_rate>
+                        <net_export_rate units="total substrate/min">0</net_export_rate>
+                    </substrate>
+                </secretion>
+                <cell_interactions>
+                    <apoptotic_phagocytosis_rate units="1/min">0</apoptotic_phagocytosis_rate>
+                    <necrotic_phagocytosis_rate units="1/min">0</necrotic_phagocytosis_rate>
+                    <other_dead_phagocytosis_rate units="1/min">0</other_dead_phagocytosis_rate>
+                    <live_phagocytosis_rates>
+                        <phagocytosis_rate name="default" units="1/min">0</phagocytosis_rate>
+                    </live_phagocytosis_rates>
+                    <attack_rates>
+                        <attack_rate name="default" units="1/min">0</attack_rate>
+                    </attack_rates>
+                    <attack_damage_rate units="1/min">1</attack_damage_rate>
+                    <attack_duration units="min">0.1</attack_duration>
+                    <fusion_rates>
+                        <fusion_rate name="default" units="1/min">0</fusion_rate>
+                    </fusion_rates>
+                </cell_interactions>
+                <cell_transformations>
+                    <transformation_rates>
+                        <transformation_rate name="default" units="1/min">0</transformation_rate>
+                    </transformation_rates>
+                </cell_transformations>
+                <cell_integrity>
+                    <damage_rate units="1/min">0.0</damage_rate>
+                    <damage_repair_rate units="1/min">0.0</damage_repair_rate>
+                </cell_integrity>
+            </phenotype>
+            <custom_data>
+                <sample conserved="false" units="dimensionless" description="">1.0</sample>
+            </custom_data>
+            <initial_parameter_distributions enabled="false">
+                <distribution enabled="false" type="Log10Normal" check_base="true">
+                    <behavior>Volume</behavior>
+                    <mu>4</mu>
+                    <sigma>2</sigma>
+                    <upper_bound>100000</upper_bound>
+                </distribution>
+                <distribution enabled="false" type="LogUniform" check_base="true">
+                    <behavior>apoptosis</behavior>
+                    <min>1e-6</min>
+                    <max>1e-2</max>
+                </distribution>
+            </initial_parameter_distributions>
+        </cell_definition>
+        <cell_definition name="type3" ID="3">
+            <phenotype>
+                <cycle code="5" name="live">
+                    <phase_transition_rates units="1/min">
+                        <rate start_index="0" end_index="0" fixed_duration="false">0</rate>
+                    </phase_transition_rates>
+                </cycle>
+                <death>
+                    <model code="100" name="apoptosis">
+                        <death_rate units="1/min">0</death_rate>
+                        <phase_durations units="min">
+                            <duration index="0" fixed_duration="true">516</duration>
+                        </phase_durations>
+                        <parameters>
+                            <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                            <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                            <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                            <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                            <calcification_rate units="1/min">0</calcification_rate>
+                            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                        </parameters>
+                    </model>
+                    <model code="101" name="necrosis">
+                        <death_rate units="1/min">0.0</death_rate>
+                        <phase_durations units="min">
+                            <duration index="0" fixed_duration="true">0</duration>
+                            <duration index="1" fixed_duration="true">86400</duration>
+                        </phase_durations>
+                        <parameters>
+                            <unlysed_fluid_change_rate units="1/min">1.11667e-2</unlysed_fluid_change_rate>
+                            <lysed_fluid_change_rate units="1/min">8.33333e-4</lysed_fluid_change_rate>
+                            <cytoplasmic_biomass_change_rate units="1/min">5.33333e-5</cytoplasmic_biomass_change_rate>
+                            <nuclear_biomass_change_rate units="1/min">2.16667e-3</nuclear_biomass_change_rate>
+                            <calcification_rate units="1/min">0</calcification_rate>
+                            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                        </parameters>
+                    </model>
+                </death>
+                <volume>
+                    <total units="micron^3">2494</total>
+                    <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+                    <nuclear units="micron^3">540</nuclear>
+                    <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+                    <calcified_fraction units="dimensionless">0</calcified_fraction>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </volume>
+                <mechanics>
+                    <cell_cell_adhesion_strength units="micron/min">0.4</cell_cell_adhesion_strength>
+                    <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+                    <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+                    <cell_adhesion_affinities>
+                        <cell_adhesion_affinity name="default">1</cell_adhesion_affinity>
+                    </cell_adhesion_affinities>
+                    <options>
+                        <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                        <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+                    </options>
+                    <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+                    <attachment_rate units="1/min">0.0</attachment_rate>
+                    <detachment_rate units="1/min">0.0</detachment_rate>
+                    <maximum_number_of_attachments>12</maximum_number_of_attachments>
+                </mechanics>
+                <motility>
+                    <speed units="micron/min">1</speed>
+                    <persistence_time units="min">1</persistence_time>
+                    <migration_bias units="dimensionless">.5</migration_bias>
+                    <options>
+                        <enabled>false</enabled>
+                        <use_2D>true</use_2D>
+                        <chemotaxis>
+                            <enabled>false</enabled>
+                            <substrate>substrate</substrate>
+                            <direction>1</direction>
+                        </chemotaxis>
+                        <advanced_chemotaxis>
+                            <enabled>false</enabled>
+                            <normalize_each_gradient>false</normalize_each_gradient>
+                            <chemotactic_sensitivities>
+                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
+                            </chemotactic_sensitivities>
+                        </advanced_chemotaxis>
+                    </options>
+                </motility>
+                <secretion>
+                    <substrate name="substrate">
+                        <secretion_rate units="1/min">0</secretion_rate>
+                        <secretion_target units="substrate density">1</secretion_target>
+                        <uptake_rate units="1/min">0</uptake_rate>
+                        <net_export_rate units="total substrate/min">0</net_export_rate>
+                    </substrate>
+                </secretion>
+                <cell_interactions>
+                    <apoptotic_phagocytosis_rate units="1/min">0</apoptotic_phagocytosis_rate>
+                    <necrotic_phagocytosis_rate units="1/min">0</necrotic_phagocytosis_rate>
+                    <other_dead_phagocytosis_rate units="1/min">0</other_dead_phagocytosis_rate>
+                    <live_phagocytosis_rates>
+                        <phagocytosis_rate name="default" units="1/min">0</phagocytosis_rate>
+                    </live_phagocytosis_rates>
+                    <attack_rates>
+                        <attack_rate name="default" units="1/min">0</attack_rate>
+                    </attack_rates>
+                    <attack_damage_rate units="1/min">1</attack_damage_rate>
+                    <attack_duration units="min">0.1</attack_duration>
+                    <fusion_rates>
+                        <fusion_rate name="default" units="1/min">0</fusion_rate>
+                    </fusion_rates>
+                </cell_interactions>
+                <cell_transformations>
+                    <transformation_rates>
+                        <transformation_rate name="default" units="1/min">0</transformation_rate>
+                    </transformation_rates>
+                </cell_transformations>
+                <cell_integrity>
+                    <damage_rate units="1/min">0.0</damage_rate>
+                    <damage_repair_rate units="1/min">0.0</damage_repair_rate>
+                </cell_integrity>
+            </phenotype>
+            <custom_data>
+                <sample conserved="false" units="dimensionless" description="">1.0</sample>
+            </custom_data>
+            <initial_parameter_distributions enabled="false">
+                <distribution enabled="false" type="Log10Normal" check_base="true">
+                    <behavior>Volume</behavior>
+                    <mu>4</mu>
+                    <sigma>2</sigma>
+                    <upper_bound>100000</upper_bound>
+                </distribution>
+                <distribution enabled="false" type="LogUniform" check_base="true">
+                    <behavior>apoptosis</behavior>
+                    <min>1e-6</min>
+                    <max>1e-2</max>
+                </distribution>
+            </initial_parameter_distributions>
+        </cell_definition>
+        <cell_definition name="type4" ID="4">
+            <phenotype>
+                <cycle code="5" name="live">
+                    <phase_transition_rates units="1/min">
+                        <rate start_index="0" end_index="0" fixed_duration="false">0</rate>
+                    </phase_transition_rates>
+                </cycle>
+                <death>
+                    <model code="100" name="apoptosis">
+                        <death_rate units="1/min">0</death_rate>
+                        <phase_durations units="min">
+                            <duration index="0" fixed_duration="true">516</duration>
+                        </phase_durations>
+                        <parameters>
+                            <unlysed_fluid_change_rate units="1/min">0.05</unlysed_fluid_change_rate>
+                            <lysed_fluid_change_rate units="1/min">0</lysed_fluid_change_rate>
+                            <cytoplasmic_biomass_change_rate units="1/min">1.66667e-02</cytoplasmic_biomass_change_rate>
+                            <nuclear_biomass_change_rate units="1/min">5.83333e-03</nuclear_biomass_change_rate>
+                            <calcification_rate units="1/min">0</calcification_rate>
+                            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                        </parameters>
+                    </model>
+                    <model code="101" name="necrosis">
+                        <death_rate units="1/min">0.0</death_rate>
+                        <phase_durations units="min">
+                            <duration index="0" fixed_duration="true">0</duration>
+                            <duration index="1" fixed_duration="true">86400</duration>
+                        </phase_durations>
+                        <parameters>
+                            <unlysed_fluid_change_rate units="1/min">1.11667e-2</unlysed_fluid_change_rate>
+                            <lysed_fluid_change_rate units="1/min">8.33333e-4</lysed_fluid_change_rate>
+                            <cytoplasmic_biomass_change_rate units="1/min">5.33333e-5</cytoplasmic_biomass_change_rate>
+                            <nuclear_biomass_change_rate units="1/min">2.16667e-3</nuclear_biomass_change_rate>
+                            <calcification_rate units="1/min">0</calcification_rate>
+                            <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                        </parameters>
+                    </model>
+                </death>
+                <volume>
+                    <total units="micron^3">2494</total>
+                    <fluid_fraction units="dimensionless">0.75</fluid_fraction>
+                    <nuclear units="micron^3">540</nuclear>
+                    <fluid_change_rate units="1/min">0.05</fluid_change_rate>
+                    <cytoplasmic_biomass_change_rate units="1/min">0.0045</cytoplasmic_biomass_change_rate>
+                    <nuclear_biomass_change_rate units="1/min">0.0055</nuclear_biomass_change_rate>
+                    <calcified_fraction units="dimensionless">0</calcified_fraction>
+                    <calcification_rate units="1/min">0</calcification_rate>
+                    <relative_rupture_volume units="dimensionless">2.0</relative_rupture_volume>
+                </volume>
+                <mechanics>
+                    <cell_cell_adhesion_strength units="micron/min">0.4</cell_cell_adhesion_strength>
+                    <cell_cell_repulsion_strength units="micron/min">10.0</cell_cell_repulsion_strength>
+                    <relative_maximum_adhesion_distance units="dimensionless">1.25</relative_maximum_adhesion_distance>
+                    <cell_adhesion_affinities>
+                        <cell_adhesion_affinity name="default">1</cell_adhesion_affinity>
+                    </cell_adhesion_affinities>
+                    <options>
+                        <set_relative_equilibrium_distance enabled="false" units="dimensionless">1.8</set_relative_equilibrium_distance>
+                        <set_absolute_equilibrium_distance enabled="false" units="micron">15.12</set_absolute_equilibrium_distance>
+                    </options>
+                    <attachment_elastic_constant units="1/min">0.01</attachment_elastic_constant>
+                    <attachment_rate units="1/min">0.0</attachment_rate>
+                    <detachment_rate units="1/min">0.0</detachment_rate>
+                    <maximum_number_of_attachments>12</maximum_number_of_attachments>
+                </mechanics>
+                <motility>
+                    <speed units="micron/min">1</speed>
+                    <persistence_time units="min">1</persistence_time>
+                    <migration_bias units="dimensionless">.5</migration_bias>
+                    <options>
+                        <enabled>false</enabled>
+                        <use_2D>true</use_2D>
+                        <chemotaxis>
+                            <enabled>false</enabled>
+                            <substrate>substrate</substrate>
+                            <direction>1</direction>
+                        </chemotaxis>
+                        <advanced_chemotaxis>
+                            <enabled>false</enabled>
+                            <normalize_each_gradient>false</normalize_each_gradient>
+                            <chemotactic_sensitivities>
+                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
+                            </chemotactic_sensitivities>
+                        </advanced_chemotaxis>
+                    </options>
+                </motility>
+                <secretion>
+                    <substrate name="substrate">
+                        <secretion_rate units="1/min">0</secretion_rate>
+                        <secretion_target units="substrate density">1</secretion_target>
+                        <uptake_rate units="1/min">0</uptake_rate>
+                        <net_export_rate units="total substrate/min">0</net_export_rate>
+                    </substrate>
+                </secretion>
+                <cell_interactions>
+                    <apoptotic_phagocytosis_rate units="1/min">0</apoptotic_phagocytosis_rate>
+                    <necrotic_phagocytosis_rate units="1/min">0</necrotic_phagocytosis_rate>
+                    <other_dead_phagocytosis_rate units="1/min">0</other_dead_phagocytosis_rate>
+                    <live_phagocytosis_rates>
+                        <phagocytosis_rate name="default" units="1/min">0</phagocytosis_rate>
+                    </live_phagocytosis_rates>
+                    <attack_rates>
+                        <attack_rate name="default" units="1/min">0</attack_rate>
+                    </attack_rates>
+                    <attack_damage_rate units="1/min">1</attack_damage_rate>
+                    <attack_duration units="min">0.1</attack_duration>
+                    <fusion_rates>
+                        <fusion_rate name="default" units="1/min">0</fusion_rate>
+                    </fusion_rates>
+                </cell_interactions>
+                <cell_transformations>
+                    <transformation_rates>
+                        <transformation_rate name="default" units="1/min">0</transformation_rate>
+                    </transformation_rates>
+                </cell_transformations>
+                <cell_integrity>
+                    <damage_rate units="1/min">0.0</damage_rate>
+                    <damage_repair_rate units="1/min">0.0</damage_repair_rate>
+                </cell_integrity>
+            </phenotype>
+            <custom_data>
+                <sample conserved="false" units="dimensionless" description="">1.0</sample>
+            </custom_data>
+            <initial_parameter_distributions enabled="false">
+                <distribution enabled="false" type="Log10Normal" check_base="true">
+                    <behavior>Volume</behavior>
+                    <mu>4</mu>
+                    <sigma>2</sigma>
+                    <upper_bound>100000</upper_bound>
+                </distribution>
+                <distribution enabled="false" type="LogUniform" check_base="true">
+                    <behavior>apoptosis</behavior>
+                    <min>1e-6</min>
+                    <max>1e-2</max>
+                </distribution>
+            </initial_parameter_distributions>
+        </cell_definition>
+    </cell_definitions>
+
+    <initial_conditions>
+        <cell_positions type="csv" enabled="true">
+            <folder>./config</folder>
+            <filename>cells.csv</filename>
+        </cell_positions>
+    </initial_conditions>
+
+    <cell_rules>
+        <rulesets>
+            <ruleset protocol="CBHG" version="3.0" format="csv" enabled="true">
+                <folder>./config</folder>
+                <filename>cell_rules_weights.csv</filename>
+            </ruleset>
+        </rulesets>
+        <settings />
+    </cell_rules>
+
+    <user_parameters>
+        <number_of_cells type="int" units="none" description="initial number of cells (for each cell type)">0</number_of_cells>
+    </user_parameters>
+</PhysiCell_settings>

--- a/sample_projects/extended_asym_div/config/cell_rules_weights.csv
+++ b/sample_projects/extended_asym_div/config/cell_rules_weights.csv
@@ -1,0 +1,3 @@
+type0,time,increases,extended asymmetric division to type1 and type2,1.0,600,256,0
+type0,time,decreases,extended asymmetric division to type1 and type2,0.0,1200,256,0
+type0,time,increases,extended asymmetric division to type3 and type4,1.0,1200,256,0


### PR DESCRIPTION
The `my-physicell` counterpart of drbergman/PhysiCell#67, which targets `feature-extended-asym-div`. Two commits, reviewable in order.

`my-physicell` already carries the `resume_from_MultiCellDS` fix that the other PR needs, so only these two land here. The resume block was taken from this branch verbatim over there, so the two trees agree on it.

## 1. Adjust asymmetric division probabilities whenever they sum past 1

`asymmetric_division_function` entered its renormalization block on `total > 1.0 + tolerance`. That block *rewrites the symmetric division probability*, so gating it on a user-settable threshold let the tolerance change the model, not just its strictness.

With `tolerance = 0.5` and probabilities of 0.3 for `(stem, stem)` and 1.0 for `(stem, progenitor_1)`, the total of 1.3 fell inside the old gate, so nothing was adjusted and the draw ran against a distribution summing to 1.3. Since `select_daughter_types` draws from `[0,1)`, `(stem, stem)` kept its 0.3 instead of going to 0, and `progenitor_1` was starved to 0.7:

| gate | final cells | stem | progenitor_1 |
|---|---|---|---|
| `total > 1.0 + tolerance` | 464 | 137 (29.5%) | 327 |
| `total > 1.0` | 16 | 1 (6.2%) | 15 |

The tolerance now has one job: deciding whether the resulting symmetric probability is negative enough to be an error rather than round-off.

## 2. Add a weighted mode for asymmetric division

The values are probabilities: they must sum to at most 1, and the shortfall is the chance of symmetric division. That is awkward for the models this feature targets. The intended use is rule-driven values, and a Hypothesis Grammar rule cannot see what the other pairs currently evaluate to, so no rule set can hold a sum at or below 1. The tolerance buys slack for round-off; it cannot rescue a model whose values legitimately sum to 2 or 3.

`<asymmetric_division_mode>` in `<options>` takes `probabilities` (the default, and what an absent element means) or `weights`. Under weights the values are relative weights normalized by their own sum at each division, so scale stops mattering and each rule can be written independently.

Details worth a reviewer's attention:

- **A string, not a bool.** `xml_get_bool_value` reads a typo as `false` and silently runs the other model. A bad value here exits.
- **Model-wide, not per cell definition.** Mixing would make one rule line mean a probability for one source type and a weight for another, with nothing in the line to say which.
- **No implicit symmetric remainder under weights.** Symmetric division needs its own `(type,type)` weight. The exception is an all-zero total, which has no normalized distribution and is defined as symmetric division — no special case needed, since leaving the draw scale at 1.0 makes `select_daughter_types` fall through to the parent and daughter types unchanged.
- **Mutually exclusive with `<asymmetric_division_probability_tolerance>`**, rejected at parse time. The tolerance bounds how far probabilities may sum past 1; weights are normalized rather than bounded. An explicit `probabilities` mode alongside a tolerance stays legal, since that is unambiguous.

The draw itself is one line — `select_daughter_types` takes a `total_weight` scaling the random draw. Probability mode passes 1.0, which is exact in double precision, so no existing model's RNG stream moves.

## Verification

- **Probability mode unchanged.** Asymmetric division sample (seed 0), before vs after: 487 `.mat` byte-identical, 244 SVG and 243 XML identical once wall-clock timestamps are stripped.
- **Weights on a model already summing to 1** reproduce that baseline exactly — normalization is a true no-op at total 1.
- **Normalization math**, 4M draws per case against the built objects: `1.0/0.5/0.5` → 50/25/25, `3/1` → 75/25, `7/2/1` → 70/20/10, and `0.07/0.02/0.01` → the same 70/20/10, confirming scale-invariance. Probability mode still leaves the shortfall to symmetric division.
- **Error paths** exit non-zero with the intended message: weights + tolerance, and an invalid mode value. `probabilities` + tolerance runs.
- **Zero total**: 100% symmetric, no crash, in both modes.
- **Both build systems** clean, and each commit builds on its own.

## Sample

`extended_asym_div` gains `PhysiCell_settings_weights.xml`, `cell_rules_weights.csv`, and a README. The weights rules saturate at 1.0 where the probabilities rules use 0.5, chosen so the normalized weights reproduce the probabilities exactly — the two configs are the same model written two ways. Verified single-threaded: across all 121 snapshots the two runs agree on every cell, and the only recorded difference is the asymmetric division values themselves (`(type0,type0)` reads 0.5 in one and 1.0 in the other).

That pairing is deliberate, because the two modes renormalize differently and the difference is not subtle: **probabilities take the whole overshoot out of the symmetric entry, while weights scale every entry proportionally.** Feeding the probabilities config to weights mode unchanged gives `(type0,type0)` 1.0/1.5 = 2/3 of divisions instead of 1/2. Same numbers, different model — which is what the mutual-exclusion error exists to prevent.

One thing noticed in passing and left alone: with `<omp_num_threads>` above 1 this sample is not bit-reproducible from the seed, and because `type0` sits near a critical branching process the run-to-run spread is large (44 vs 242 final cells across two runs of the same config). That is pre-existing and unrelated; the README notes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
