### PR TITLE
Restore trim_cr on substrate csv rows and harden dirichlet csv parsing

### DIFF
--- a/BioFVM/BioFVM_microenvironment.cpp
+++ b/BioFVM/BioFVM_microenvironment.cpp
@@ -1307,6 +1307,7 @@ void load_initial_conditions_from_csv(std::string filename)
 	// determine if header row exists 
 	std::string line; 
 	std::getline( file , line );
+	trim_cr(line);
 	char c = line.c_str()[0];
 	std::vector<int> substrate_indices;
 	bool header_provided = false;
@@ -1360,6 +1361,7 @@ void load_initial_conditions_from_csv(std::string filename)
 	
 	while (std::getline(file, line))
 	{
+		trim_cr(line);
 		get_row_from_substrate_initial_condition_csv(voxel_set, line, substrate_indices, header_provided);
 	}
 	
@@ -1380,8 +1382,23 @@ void load_initial_conditions_from_csv(std::string filename)
 void get_row_from_substrate_initial_condition_csv(std::vector<int> &voxel_set, const std::string line, const std::vector<int> substrate_indices, const bool header_provided)
 {
 	static bool warning_issued = false;
+
+	if (line.find_first_not_of(" \t\r") == std::string::npos)
+	{ return; } // skip blank lines
+
 	std::vector<double> data;
 	csv_to_vector(line.c_str(), data);
+
+	// holding a row to the expected column count is also what keeps every data[...] access below in bounds
+	if (data.size() != substrate_indices.size() + 3)
+	{
+		std::cout << "ERROR : A row of the .csv file specifying BioFVM initial conditions has the wrong number of values." << std::endl
+				  << "\tExpected: " << substrate_indices.size() + 3 << " (x, y, z and " << substrate_indices.size() << " substrate value(s))" << std::endl
+				  << "\tFound: " << data.size() << std::endl
+				  << "\tNote that an empty field is not a value here; every column must hold a number." << std::endl
+				  << "\tOffending row: " << line << std::endl;
+		exit(-1);
+	}
 
 	if (!(warning_issued) && !(header_provided) && (data.size() != (microenvironment.number_of_densities() + 3)))
 	{
@@ -1715,6 +1732,10 @@ void load_dirichlet_conditions_from_csv(std::string filename)
 void get_row_from_dirichlet_condition_csv(std::vector<int> &voxel_set, const std::string line, const std::vector<int> substrate_indices, const bool header_provided, int n_cols)
 {
 	static bool warning_issued = false;
+
+	if (line.find_first_not_of(" \t\r") == std::string::npos)
+	{ return; } // skip blank lines
+
 	std::vector<bool> is_missing;
 	std::vector<double> data;
 	is_missing.resize(n_cols);

--- a/BioFVM/BioFVM_vector.cpp
+++ b/BioFVM/BioFVM_vector.cpp
@@ -47,6 +47,8 @@
 */
 
 #include "BioFVM_vector.h" 
+#include <stdexcept>
+#include <string>
 
 /* some global BioFVM strings */ 
 
@@ -376,6 +378,49 @@ void csv_to_vector( const char* buffer , std::vector<double>& vect )
 	return; 
 }
 
+// store one field of a dirichlet-condition csv row. The bounds check matters: a row carrying more
+// fields than the header established would otherwise write past the end of both vectors.
+static void store_dirichlet_csv_entry( const char* buffer , const std::string& entry , std::vector<bool>& is_missing , std::vector<double>& data , const size_t ind )
+{
+	if (ind >= is_missing.size())
+	{
+		std::cerr << "Error: Too many data supplied in a row of the .csv file specifying BioFVM dirichlet conditions." << std::endl;
+		std::cerr << "\tExpected: " << is_missing.size() << ". Found: " << ind + 1 << " or more." << std::endl;
+		std::cerr << "\tRow: " << buffer << std::endl;
+		exit(-1);
+	}
+
+	// a field holding nothing but whitespace is omitted, so that " , " reads the same as ","
+	size_t first = entry.find_first_not_of(" \t\r");
+	if (first == std::string::npos)
+	{
+		is_missing[ind] = true;
+		return;
+	}
+	std::string trimmed = entry.substr(first, entry.find_last_not_of(" \t\r") - first + 1);
+
+	double value = 0.0;
+	size_t parsed = 0;
+	try
+	{
+		value = std::stod(trimmed, &parsed);
+	}
+	catch (const std::logic_error&) // std::stod throws invalid_argument on no conversion, out_of_range on overflow
+	{
+		parsed = 0;
+	}
+	if (parsed != trimmed.size()) // no conversion, or trailing garbage as in "1.5abc"
+	{
+		std::cerr << "Error: Column " << ind + 1 << " of a row of the .csv file specifying BioFVM dirichlet conditions is not a number." << std::endl;
+		std::cerr << "\tOffending value: " << trimmed << std::endl;
+		std::cerr << "\tRow: " << buffer << std::endl;
+		exit(-1);
+	}
+
+	data[ind] = value;
+	is_missing[ind] = false;
+}
+
 void dirichlet_csv_to_vector( const char* buffer , std::vector<bool>& is_missing , std::vector<double>& data )
 {
 	size_t ind = 0;
@@ -385,15 +430,7 @@ void dirichlet_csv_to_vector( const char* buffer , std::vector<bool>& is_missing
     {
         if(buffer[i] == ',')
         {
-            if(entry.empty())
-            {
-				is_missing[ind] = true;
-            }
-            else
-            {
-				data[ind] = std::stod(entry);
-				is_missing[ind] = false;
-            }
+			store_dirichlet_csv_entry(buffer, entry, is_missing, data, ind);
             entry.clear();
 			ind++;
         }
@@ -404,15 +441,7 @@ void dirichlet_csv_to_vector( const char* buffer , std::vector<bool>& is_missing
         i++;
     }
     // Handle the last entry
-    if(entry.empty())
-    {
-		is_missing[ind] = true;
-    }
-    else
-    {
-		data[ind] = std::stod(entry);
-		is_missing[ind] = false;
-    }
+	store_dirichlet_csv_entry(buffer, entry, is_missing, data, ind);
 
 	if (is_missing[0] || is_missing[1] || is_missing[2])
 	{


### PR DESCRIPTION
Merging `development` into `feature-dc-init-file` dropped both `trim_cr` calls from `load_initial_conditions_from_csv`. `load_dirichlet_conditions_from_csv` is a near-identical copy of it, so the resolution landed development's additions on the dirichlet copy and kept this branch's untouched version of the substrate copy. That is why the branch looks like it has `trim_cr` — it does, just on the wrong function.

```
$ git show 39be5bd3:BioFVM/BioFVM_microenvironment.cpp | grep -n trim_cr   # development
1471:	trim_cr(line);      # load_initial_conditions_from_csv, header sniff
1520:	trim_cr(line);      # load_initial_conditions_from_csv, reopened first row
1528:	trim_cr(line);      # load_initial_conditions_from_csv, row loop

$ git show b2d0a175:BioFVM/BioFVM_microenvironment.cpp | grep -n trim_cr   # the merge
1642:	trim_cr(line);      # load_dirichlet_conditions_from_csv, header sniff
1706:	trim_cr(line);      # load_dirichlet_conditions_from_csv, row loop
```

The rest of #417 and #421 survived intact: `BioFVM_utilities.h`, `PhysiCell_rules.cpp` and `PhysiCell_geometry.cpp` are byte-identical to development across the merge, so the rules and cells.csv readers are unaffected. Only the third `trim_cr` is genuinely gone rather than misplaced, and it should be: this branch replaced the close-and-reopen trick it guarded with a direct call on the first row, which is already trimmed.

## What breaks without it

A CRLF `substrates.csv` with a header fails, because the final column name carries the trailing carriage return and `find_density_index("oxygen\r")` returns -1:

```
ERROR: Substrate oxygen not found in the BioFVM microenvironment. Exiting now.
```

## Out-of-bounds accesses in both row processors

Both processors indexed their parsed row without consulting its length. These are not new on this branch — development crashes on the same inputs — but the dirichlet copy inherited them, and the blank-line handling added for cells.csv in #421 never reached either one:

- A blank or whitespace-only line leaves `csv_to_vector`'s output empty, so `data[0..2]` reads past the end. The churn loop inside `csv_to_vector` also walks past the terminator hunting for a digit, which is what turns this into a SIGSEGV rather than a garbage read.
- `substrate_indices` is sized from the header, so a row with fewer columns runs `data[ci + 3]` off the end.
- `dirichlet_csv_to_vector` writes `is_missing[ind]` and `data[ind]` once per comma with no bound, so a row with **more** fields than the header established writes past the end of both vectors. Confirmed with `-D_GLIBCXX_ASSERTIONS`:

  ```
  stl_vector.h:1263: std::vector<double>::operator[](size_type):
    Assertion '__n < this->size()' failed.
  ```

- A whitespace-only field reaches `std::stod`, which throws uncaught (`terminate called after throwing an instance of 'std::invalid_argument'`). A CRLF row ending in an empty field produces exactly this, since the field is `"\r"`.

Blank lines are now skipped in both processors, matching `load_cells_csv_v1` and `process_csv_v2_line`, and a row whose column count disagrees with the header is a hard error naming the offending row rather than a silent partial write. Ordering the substrate guard ahead of the existing warning also stops `data.size() - 3` from underflowing on a short row. `dirichlet_csv_to_vector` now treats a whitespace-only field as omitted and reports a field that is not a complete finite number instead of accepting `"1.5abc"` as 1.5.

## Two behaviour changes worth a look

- **A substrates.csv row must now have exactly the header's column count**, not merely enough columns. Extra trailing columns used to be dropped silently. Exact matching is what lets a short row be diagnosed at all, and it matches where `substrate-csv-omit-voxels` is taking this function.
- **An empty field in substrates.csv is now an error.** `csv_to_vector` does not count empty fields, so `0,0,0,,6` used to assign 6 to the *first* substrate and read off the end for the second. Empty-field support on the substrate side is what `substrate-csv-omit-voxels` adds via its NaN sentinel; until that lands, rejecting the row beats misassigning it. The dirichlet side is unaffected — it has always had real missing-value semantics through `is_missing`, and `dcs.csv` in the sample project relies on them.

## Verification

Built the `dirichlet_from_file` sample with `substrates.csv` wired into `<initial_condition type="csv">` alongside its `dcs.csv`, and ran 13 variants of each file through it: LF, CRLF, no trailing newline, trailing blank line, interior blank line, whitespace-only line, CRLF blank line, headerless, headerless CRLF, and rows that are too long, too short, non-numeric, or trailing-garbage.

Before, on `b2d0a175`:

```
ic  crlf               rc=255  ERROR: Substrate oxygen not found in the BioFVM microenvironment.
ic  blank_tail         rc=139  (SIGSEGV)
ic  blank_middle       rc=139  (SIGSEGV)
ic  ws_line            rc=139  (SIGSEGV)
ic  crlf_blank_tail    rc=255  ERROR: Substrate oxygen not found in the BioFVM microenvironment.
ic  headerless_crlf    rc=138  (SIGBUS)
ic  too_many           rc=0    silently accepted
dc  blank_tail         rc=255  Error: x, y, and z data must be provided for each row ...
dc  blank_middle       rc=255  Error: x, y, and z data must be provided for each row ...
dc  ws_line            rc=134  terminate called after throwing an instance of 'std::invalid_argument'
dc  crlf_blank_tail    rc=255  Error: x, y, and z data must be provided for each row ...
dc  not_a_number       rc=134  terminate called after throwing an instance of 'std::invalid_argument'
dc  too_many           rc=0    silently accepted, writing out of bounds
dc  garbage_tail       rc=0    silently accepted "1.5abc" as 1.5
```

After, all nine well-formed variants of both files load and run clean, and all four malformed variants exit non-zero with a message naming the offending row. Re-ran the whole matrix under `-D_GLIBCXX_ASSERTIONS` with no assertion failures.

The seven well-formed variants also produce byte-identical `initial_microenvironment0.mat` and `final_microenvironment0.mat`, so CRLF, blank lines, whitespace lines, headerless and no-trailing-newline files all parse to the same thing as plain LF. Disabling either csv input changes both hashes, so that equality is not vacuous. The `template` sample also builds and runs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
