### PR TITLE
Sync Dirichlet activation by reference and give the DC setters one error policy

### DIFF
--- a/BioFVM/BioFVM_microenvironment.cpp
+++ b/BioFVM/BioFVM_microenvironment.cpp
@@ -235,7 +235,7 @@ void Microenvironment::fix_substrates_at_voxel( int voxel_index , std::vector<do
 	if (new_values.size() != dirichlet_value_vectors[voxel_index].size())
 	{
 		std::cerr << "Error: Incorrect number of values passed in to fix_substrates_at_voxel. Expected " << dirichlet_value_vectors[voxel_index].size() << " values, but got " << new_values.size() << "." << std::endl;
-		return;
+		exit(-1);
 	}
 	dirichlet_value_vectors[voxel_index] = new_values;
 	return fix_substrates_at_voxel( voxel_index );
@@ -264,7 +264,7 @@ void Microenvironment::fix_substrate_at_voxels( int substrate_index, std::vector
 	if (new_values.size() != voxel_indices.size())
 	{
 		std::cerr << "Error: new_values size (" << new_values.size() << ") does not match voxel_indices size (" << voxel_indices.size() << ") in Microenvironment::fix_substrate_at_voxels" << std::endl;
-		return;
+		exit(-1);
 	}
 	for( unsigned int i=0 ; i < voxel_indices.size() ; i++ )
 	{
@@ -339,7 +339,7 @@ void Microenvironment::unfix_substrates_at_voxel( int voxel_index )
 
 void Microenvironment::sync_substrate_dirichlet_activation( int substrate_index )
 {
-	for (auto voxel_activation_vector : dirichlet_activation_vectors)
+	for (const auto& voxel_activation_vector : dirichlet_activation_vectors)
 	{
 		if (voxel_activation_vector[substrate_index])
 		{

--- a/BioFVM/BioFVM_microenvironment.h
+++ b/BioFVM/BioFVM_microenvironment.h
@@ -231,6 +231,7 @@ class Microenvironment
 	
 	void display_information( std::ostream& os ); 
 
+	// Dirichlet setters/clearers: invalid input (unknown substrate name, mismatched vector sizes) is fatal
 	void fix_substrate_at_voxel( std::string substrate, int voxel_index, double new_value );
 	void fix_substrate_at_voxel( std::string substrate, int voxel_index );
 	void fix_substrate_at_voxels( std::string substrate, std::vector<int>& voxel_indices, double new_value );


### PR DESCRIPTION
Two cleanups to the Dirichlet setters added in `simplified dc functions` / `check size of values in (un)fix dcs`.

### `sync_substrate_dirichlet_activation` copied the whole mesh

```cpp
for (auto voxel_activation_vector : dirichlet_activation_vectors)
```

`dirichlet_activation_vectors` is a `std::vector< std::vector<bool> >` with one entry per voxel, so binding by value heap-allocated and destroyed a `vector<bool>` on every iteration just to read one element out of it. Binding by `const auto&` reads it in place. On a 50x50x50 mesh (125k voxels) a worst-case scan — no voxel has the substrate fixed, so the loop runs to the end — goes from 2.1 ms to 0.056 ms per call. `unfix_substrates_at_voxel` calls it once per substrate, so the copy was paid `number_of_densities()` times per voxel cleared.

### One error policy instead of two

The setters disagreed about what invalid input means:

| call | before |
|---|---|
| `fix_substrate_at_voxel("not_a_substrate", ...)` | `find_existing_density_index` prints and `exit(-1)` |
| `fix_substrate_at_voxels(0, voxels, values)` with `values.size() != voxels.size()` | prints, returns, nothing happens |
| `fix_substrates_at_voxel(n, values)` with the wrong count | prints, returns, nothing happens |

The two size checks made the call a silent no-op. These are `void` functions, so a caller has no way to notice: the Dirichlet condition it asked for simply isn't there, and the simulation runs on with the wrong boundary. Both now `exit(-1)`, matching the unknown-substrate-name path and the rest of the file (bad `.mat`/`.csv` input, duplicate density names, unsupported file types all exit).

The alternative — soften `find_existing_density_index` to a warning — would spread the silent-no-op problem instead of removing it, so I went the other way. The header now says so above the block, since these are public API.

No effect on well-formed calls: the size checks only fire on input that was already being rejected, and the loop change is semantics-preserving.
