### PR TITLE
Stop copying Dirichlet csv rows and fix the warning's expected count

### DIFF
--- a/BioFVM/BioFVM_microenvironment.cpp
+++ b/BioFVM/BioFVM_microenvironment.cpp
@@ -1699,7 +1699,7 @@ void load_dirichlet_conditions_from_csv(std::string filename)
 	return;
 }
 
-void get_row_from_dirichlet_condition_csv(std::vector<bool> &voxel_is_set, const std::string line, const std::vector<int> substrate_indices, const bool header_provided, int n_cols)
+void get_row_from_dirichlet_condition_csv(std::vector<bool> &voxel_is_set, const std::string &line, const std::vector<int> &substrate_indices, const bool header_provided, int n_cols)
 {
 	static bool warning_issued = false;
 	std::vector<bool> is_missing;
@@ -1712,7 +1712,7 @@ void get_row_from_dirichlet_condition_csv(std::vector<bool> &voxel_is_set, const
 	if (!(warning_issued) && !(header_provided) && (data.size() != (microenvironment.number_of_densities() + 3)))
 	{
 		std::cout << "WARNING: Wrong number of density data supplied in the .csv file specifying BioFVM dirichlet conditions." << std::endl
-				  << "\tExpected: " << microenvironment.number_of_voxels() << std::endl
+				  << "\tExpected: " << microenvironment.number_of_densities() << std::endl
 				  << "\tFound: " << data.size() - 3 << std::endl
 				  << "\tRemember, save your csv with columns as: x, y, z, substrate_0, substrate_1,...." << std::endl
 				  << "\tThis could also be resolved by including a header row \"x,y,z,[substrate_i0,substrate_i1]\"" << std::endl;

--- a/BioFVM/BioFVM_microenvironment.h
+++ b/BioFVM/BioFVM_microenvironment.h
@@ -381,7 +381,7 @@ void set_dirichlet_boundaries_from_XML( void );
 void set_dirichlet_boundaries_from_file( void );
 void load_dirichlet_conditions_from_matlab( std::string filename );
 void load_dirichlet_conditions_from_csv(std::string filename);
-void get_row_from_dirichlet_condition_csv(std::vector<bool> &voxel_is_set, const std::string line, const std::vector<int> substrate_indices, const bool header_provided, int n_cols);
+void get_row_from_dirichlet_condition_csv(std::vector<bool> &voxel_is_set, const std::string &line, const std::vector<int> &substrate_indices, const bool header_provided, int n_cols);
 };
 
 #endif


### PR DESCRIPTION
The my-physicell counterpart of #72. Note up front that the two defects #72 fixes have no direct counterpart here: `sync_substrate_dirichlet_activation`, the `fix_/unfix_substrate_at_voxel(s)` family and `find_existing_density_index` are all new on `dc-rework` and don't exist on this branch, so there is no mesh-copying loop and no split error policy to unify. What does correspond is in the Dirichlet-from-file reader.

`get_row_from_dirichlet_condition_csv` took `line` and `substrate_indices` by value, copying a string and heap-allocating a vector for every row of the file; both are now `const&`. This is the same change #69 makes to the substrate reader's twin signature, and it touches a different function, so the two shouldn't collide.

The "wrong number of density data" warning in that function printed `number_of_voxels()` where it means `number_of_densities()` — `Found` is a count of substrate columns, and `load_dirichlet_conditions_from_matlab`'s equivalent message already uses the density count. Worth knowing: that warning is unreachable today. In the header-less branch of `load_dirichlet_conditions_from_csv`, `i` is never incremented past the `continue`, so `substrate_indices` ends up empty, and the re-opened `std::ifstream file` shadows the outer one and dies at the end of the block, leaving the outer stream closed. A header-less DC csv therefore sets nothing at all, silently. That is the Dirichlet twin of the header-less path #69 revives for substrates, and it is still missing — happy to do it as a follow-up if you want it in this round.
