### PR TITLE
Remove stray semicolon from two PhysiBoSS samples' main.cpp

### DIFF
--- a/sample_projects_intracellular/boolean/template_BM/main.cpp
+++ b/sample_projects_intracellular/boolean/template_BM/main.cpp
@@ -89,7 +89,7 @@ int main( int argc, char* argv[] )
 	// read arguments
 	argument_parser.parse(argc, argv);
 	
-	if( !load_PhysiCell_config_file(); )
+	if( !load_PhysiCell_config_file() )
 	{ exit(-1);}
 	
 	// OpenMP setup

--- a/sample_projects_intracellular/boolean/tutorial/main.cpp
+++ b/sample_projects_intracellular/boolean/tutorial/main.cpp
@@ -90,7 +90,7 @@ int main( int argc, char* argv[] )
 	argument_parser.parse(argc, argv);
 
 	// load and parse settings file(s)
-	if( !load_PhysiCell_config_file(); )
+	if( !load_PhysiCell_config_file() )
 	{ exit(-1);}
 
 	if( argc > 1 )


### PR DESCRIPTION
`template_BM` and `tutorial` both wrote a stray semicolon inside the `if` condition, so neither sample compiled at all:

```cpp
if( !load_PhysiCell_config_file(); )
{ exit(-1);}
```

```
main.cpp:92:13: warning: init-statement in selection statements only available with '-std=c++17' [-Wc++17-extensions]
main.cpp:92:44: error: expected primary-expression before ')' token
```

`cancer_invasion/main.cpp` already has the intended form, which is what these two are now matched to. Introduced in 7eba0106, when these samples moved to the `argument_parser` + `load_PhysiCell_config_file()` API.

**Scope.** Two occurrences, and they are the only ones in the repository:

```
$ grep -rnE "\b(if|while)\s*\(.*\(\)\s*;\s*\)" --include="*.cpp" --include="*.h" .
sample_projects_intracellular/boolean/template_BM/main.cpp:92
sample_projects_intracellular/boolean/tutorial/main.cpp:93
```

Not present on `upstream/development`, which still uses the older `XML_status = load_PhysiCell_config_file( argv[1] )` form — so this is fork-only and needs no upstream PR.

**Why it matters.** This is what fails "Testing PhysiBoSS Template" and "Testing PhysiBoSS Tutorial" on Ubuntu, Windows and MacOS 14 on *every* PR against `my-physicell`, plus the `windows (template_BM, ...)` and `macos_step0b (template_BM, ...)` build jobs. I found it while confirming that #71's CI failures were pre-existing rather than its own — the identical error appears on `c7ff0946`.

**Verification.** Both samples now build, link and run locally:

- `make template_BM && make` links, and `./project` completes.
- `make physiboss-tutorial && make` links, and `./project ./config/cell_cycle/PhysiCell_settings.xml` completes. Worth noting that this sample ships *no* top-level config — only the `cell_cycle/`, `differentiation/` and `simple_tnf/` scenario subdirectories, each with its own settings XML and `cells.csv` — so invoking it with the default `./config/PhysiCell_settings.xml` exits with "cells.csv not found" regardless of this fix.

**What this does not fix.** The same jobs also hit `make[2]: *** [Makefile.maboss:193: BooleanNetwork_256n.o] Error 127`. Error 127 is "command not found", so it is a missing tool in the CI MaBoSS build rather than anything in this tree — MaBoSS built here without trouble (flex and bison both present). Those jobs may stay red on that second cause; worth a separate look at the workflow's dependency install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)